### PR TITLE
Use issuer public key, DN and serial number for Authority Key Identifier extension

### DIFF
--- a/kse/src/net/sf/keystore_explorer/gui/dialogs/DGenerateKeyPairCert.java
+++ b/kse/src/net/sf/keystore_explorer/gui/dialogs/DGenerateKeyPairCert.java
@@ -319,6 +319,18 @@ public class DGenerateKeyPairCert extends JEscDialog {
 			caName = X500Name.getInstance(issuerCert.getSubjectDN());
 			caPublicKey = issuerCert.getPublicKey();
 			caSerialNumber = issuerCert.getSerialNumber();
+		} else {
+			caName = jdnName.getDistinguishedName(); // May be null
+			caPublicKey = keyPair.getPublic();
+
+			String serialNumberStr = jtfSerialNumber.getText().trim();
+			if (serialNumberStr.length() != 0) {
+				try {
+					caSerialNumber = new BigInteger(serialNumberStr);
+				} catch (NumberFormatException ex) {
+					// Don't set serial number
+				}
+			}
 		}
 
 		DAddExtensions dAddExtensions = new DAddExtensions(this, extensions, caPublicKey, caName, caSerialNumber, subjectPublicKey);

--- a/kse/src/net/sf/keystore_explorer/gui/dialogs/DGenerateKeyPairCert.java
+++ b/kse/src/net/sf/keystore_explorer/gui/dialogs/DGenerateKeyPairCert.java
@@ -311,21 +311,17 @@ public class DGenerateKeyPairCert extends JEscDialog {
 	}
 
 	private void addExtensionsPressed() {
-		PublicKey publicKey = keyPair.getPublic();
-		X500Name name = jdnName.getDistinguishedName(); // May be null
-		BigInteger serialNumber = null;
-
-		String serialNumberStr = jtfSerialNumber.getText().trim();
-
-		if (serialNumberStr.length() != 0) {
-			try {
-				serialNumber = new BigInteger(serialNumberStr);
-			} catch (NumberFormatException ex) {
-				// Don't set serial number
-			}
+		PublicKey subjectPublicKey = keyPair.getPublic();
+		PublicKey caPublicKey = null;
+		X500Name caName = null;
+		BigInteger caSerialNumber = null;
+		if (issuerCert != null) {
+			caName = X500Name.getInstance(issuerCert.getSubjectDN());
+			caPublicKey = issuerCert.getPublicKey();
+			caSerialNumber = issuerCert.getSerialNumber();
 		}
 
-		DAddExtensions dAddExtensions = new DAddExtensions(this, extensions, publicKey, name, serialNumber, publicKey);
+		DAddExtensions dAddExtensions = new DAddExtensions(this, extensions, caPublicKey, caName, caSerialNumber, subjectPublicKey);
 		dAddExtensions.setLocationRelativeTo(this);
 		dAddExtensions.setVisible(true);
 


### PR DESCRIPTION
KSE uses subject public key and subject name and certificate serial number for creating Authority Key Identity extension. It is wrong, it should be issuer (authority) public key, issuer name and issuer certificate serial number.