### PR TITLE
This fixes the splash screen that was not visible, and clean up things.

### DIFF
--- a/kse/build.xml
+++ b/kse/build.xml
@@ -247,7 +247,7 @@
 		</tstamp>
 
 		<!-- KSE jar -->
-		<manifestclasspath property="classPath" jarfile="${jar}">
+		<manifestclasspath property="classPath" jarfile="${jar}" unless:set="classPath" maxParentLevels="1">
 			<classpath refid="distClasspath" />
 		</manifestclasspath>
 		<manifest file="${mfFile}">

--- a/kse/res/kse.sh.in
+++ b/kse/res/kse.sh.in
@@ -2,10 +2,6 @@
 #
 # @appName@ startup script
 
-_prefer_jre=true
-if [ -r /usr/share/java-utils/java-functions ]; then
-	. /usr/share/java-utils/java-functions
-fi
 if [ -f /etc/java/@appSimpleName@.conf ]; then
 	. /etc/java/@appSimpleName@.conf
 fi
@@ -13,12 +9,7 @@ if [ -f ${XDG_CONFIG_HOME:-$HOME/.config}/@appSimpleName@ ]; then
 	. ${XDG_CONFIG_HOME:-$HOME/.config}/@appSimpleName@
 fi
 
-MAIN_CLASS=@mainClass@
 BASE_OPTIONS="-Dkse.update.disabled=true"
-BASE_JARS="@classPath@ @appSimpleName@"
+MAIN_JAR="/usr/share/java/@appSimpleName@.jar"
 
-set_jvm
-set_classpath $BASE_JARS
-set_options $BASE_OPTIONS
-
-run "$@"
+java $BASE_OPTIONS -jar $MAIN_JAR "$@"


### PR DESCRIPTION
- Add unless:set="classPath" in the build.xml manifestclasspath tag to be able to set the classpath in the manifest at build time
- Set the manifest classpath at build time to correct its bad values
(remove the lib directory) to be able to start KSE in jar mode (java
-jar)
- Rework the template start up script to start KSE in jar mode to able
to see the splash screen that was not visible with jpackage_script
- Drop the %{jpackage_script} macro in favor of our template start up
script
- Clean up the deps and the spec file: remove our get_property() macro
and the libxml2-utils build requirement that it needed.