### PR TITLE
French missing translation of the splash screen strings

### DIFF
--- a/kse/packaging/SPECS/keystore-explorer.spec
+++ b/kse/packaging/SPECS/keystore-explorer.spec
@@ -4,7 +4,7 @@
 %define get_property() xmllint --xpath 'string(//property[@name="%1"]/@value)' %2
 
 %define major 1
-%define gitversion 20160424
+%define gitversion 20160427
 %define rel 1
 
 %if 0%{?gitversion}
@@ -119,7 +119,7 @@ desktop-file-install \
 
 
 %changelog
-* Tue Apr 26 2016 Davy Defaud <davy.defaud@free.fr> 5.2.0-0.git20160426.1
+* Tue Apr 26 2016 Davy Defaud <davy.defaud@free.fr> 5.2.0-0.git20160427.1
 - Add unless:set="classPath" in the build.xml manifestclasspath tag to be able
  to set the classpath in the manifest at build time
 - Set the manifest classpath at build time to correct its bad values (remove the

--- a/kse/src/net/sf/keystore_explorer/resources_fr.properties
+++ b/kse/src/net/sf/keystore_explorer/resources_fr.properties
@@ -25,6 +25,6 @@
 
 
 # Splash screen messages
-KSE.LoadingApplicationSettings.splash.message=Chargement des préférences\u2026
-KSE.InitializingSecurity.splash.message=Initialisation de la sécurité\u2026
-KSE.CreatingApplicationGui.splash.message=Création de l\u2019interface graphique\u2026
+KSE.LoadingApplicationSettings.splash.message=Chargement des pr\u00e9f\u00e9rences\u2026
+KSE.InitializingSecurity.splash.message=Initialisation de la s\u00e9curit\u00e9\u2026
+KSE.CreatingApplicationGui.splash.message=Cr\u00e9ation de l\u2019interface graphique\u2026

--- a/kse/src/net/sf/keystore_explorer/resources_fr.properties
+++ b/kse/src/net/sf/keystore_explorer/resources_fr.properties
@@ -25,7 +25,6 @@
 
 
 # Splash screen messages
-KSE.LoadingApplicationSettings.splash.message=Loading Settings...
-KSE.InitializingSecurity.splash.message=Initializing Security...
-KSE.CreatingApplicationGui.splash.message=Creating Application GUI...
-
+KSE.LoadingApplicationSettings.splash.message=Chargement des préférences\u2026
+KSE.InitializingSecurity.splash.message=Initialisation de la sécurité\u2026
+KSE.CreatingApplicationGui.splash.message=Création de l\u2019interface graphique\u2026


### PR DESCRIPTION
It needs a fix for the character encoding!
Unicode UTF-8 multibyte characters are displayed as several characters in the splash screen... :-(

Update: fixed by my latest commit converting the multibyte characters to Unicode escapes. But still a mystery...