### PR TITLE
Define provider when generating EC key pair

### DIFF
--- a/kse/src/net/sf/keystore_explorer/crypto/keypair/KeyPairUtil.java
+++ b/kse/src/net/sf/keystore_explorer/crypto/keypair/KeyPairUtil.java
@@ -154,14 +154,20 @@ public final class KeyPairUtil {
 	 *
 	 * @param curveName
 	 *            Name of the ECC curve
+	 * @param provider A JCE provider.
 	 * @return A key pair
 	 * @throws CryptoException
 	 *             If there was a problem generating the key pair
 	 */
-	public static KeyPair generateECKeyPair(String curveName) throws CryptoException {
+	public static KeyPair generateECKeyPair(String curveName, Provider provider) throws CryptoException {
 		try {
 			// Get a key pair generator
-			KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance(KeyPairType.EC.jce(), BOUNCY_CASTLE.jce());
+			KeyPairGenerator keyPairGen;
+			if (provider != null) {
+				keyPairGen = KeyPairGenerator.getInstance(KeyPairType.EC.jce(), provider);
+			} else {
+				keyPairGen = KeyPairGenerator.getInstance(KeyPairType.EC.jce(), BOUNCY_CASTLE.jce());
+			}
 
 			keyPairGen.initialize(new ECGenParameterSpec(curveName), SecureRandom.getInstance("SHA1PRNG"));
 

--- a/kse/src/net/sf/keystore_explorer/gui/actions/GenerateKeyPairAction.java
+++ b/kse/src/net/sf/keystore_explorer/gui/actions/GenerateKeyPairAction.java
@@ -132,7 +132,7 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
 				applicationSettings.setGenerateKeyPairType(keyPairType);
 			} else {
 				String curveName = dGenerateKeyPair.getCurveName();
-				dGeneratingKeyPair = new DGeneratingKeyPair(frame, keyPairType, curveName);
+				dGeneratingKeyPair = new DGeneratingKeyPair(frame, keyPairType, curveName, provider);
 			}
 
 			dGeneratingKeyPair.setLocationRelativeTo(frame);

--- a/kse/src/net/sf/keystore_explorer/gui/dialogs/DGeneratingKeyPair.java
+++ b/kse/src/net/sf/keystore_explorer/gui/dialogs/DGeneratingKeyPair.java
@@ -103,10 +103,11 @@ public class DGeneratingKeyPair extends JEscDialog {
 	 * @param curveName
 	 *            The name of the curve to create
 	 */
-	public DGeneratingKeyPair(JFrame parent, KeyPairType keyPairType, String curveName) {
+	public DGeneratingKeyPair(JFrame parent, KeyPairType keyPairType, String curveName, Provider provider) {
 		super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
 		this.keyPairType = keyPairType;
 		this.curveName = curveName;
+		this.provider = provider;
 		initComponents();
 	}
 
@@ -205,9 +206,7 @@ public class DGeneratingKeyPair extends JEscDialog {
 				if (keyPairType != KeyPairType.EC) {
 					keyPair = KeyPairUtil.generateKeyPair(keyPairType, keySize, provider);
 				} else {
-
-					// TODO handle hardware providers
-					keyPair = KeyPairUtil.generateECKeyPair(curveName);
+					keyPair = KeyPairUtil.generateECKeyPair(curveName, provider);
 				}
 
 				SwingUtilities.invokeLater(new Runnable() {


### PR DESCRIPTION
This patch adds the ability to specify a provider when generating ECC keys. This is required for ECC keys generated on hardware.