### PR TITLE
Ignore unknown certificate types

### DIFF
--- a/kse/src/net/sf/keystore_explorer/crypto/keystore/KeyStoreUtil.java
+++ b/kse/src/net/sf/keystore_explorer/crypto/keystore/KeyStoreUtil.java
@@ -557,4 +557,24 @@ public final class KeyStoreUtil {
 		String algorithm = certificate.getPublicKey().getAlgorithm();
 		return algorithm.equals(EC.jce());
 	}
+	
+	/**
+	 * Is the certificate type supported (e.g. exclude Card Verifiable Certificates)
+	 * 
+	 * @param alias
+	 *            Alias of key pair entry
+	 * @param keyStore
+	 *            KeyStore that contains the key pair or certificate
+	 * @return True, if certificate is supported or entry is a secret key
+	 * @throws KeyStoreException
+	 *                If there was a problem accessing the KeyStore.
+	 */
+	public static boolean isSupportedCertificateType(String alias, KeyStore keyStore) throws KeyStoreException {
+		if (!isKeyPairEntry(alias, keyStore)) {
+			return true;
+		}
+
+		Certificate certificate = keyStore.getCertificate(alias);
+		return (certificate instanceof X509Certificate);
+	}
 }

--- a/kse/src/net/sf/keystore_explorer/gui/KeyStoreTableModel.java
+++ b/kse/src/net/sf/keystore_explorer/gui/KeyStoreTableModel.java
@@ -110,6 +110,9 @@ public class KeyStoreTableModel extends AbstractTableModel {
 
 		while (aliases.hasMoreElements()) {
 			String alias = aliases.nextElement();
+			if (!KeyStoreUtil.isSupportedCertificateType(alias, keyStore)) {
+				continue;
+			}
 			sortedAliases.put(alias, alias);
 		}
 

--- a/kse/src/net/sf/keystore_explorer/gui/dialogs/DProperties.java
+++ b/kse/src/net/sf/keystore_explorer/gui/dialogs/DProperties.java
@@ -38,6 +38,7 @@ import java.security.PrivateKey;
 import java.security.ProviderException;
 import java.security.PublicKey;
 import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.DSAParams;
@@ -448,6 +449,10 @@ public class DProperties extends JEscDialog {
 
 			createPrivateKeyNodes(keyPairNode, alias);
 
+			if (!KeyStoreUtil.isSupportedCertificateType(alias, keyStore)) {
+				return;
+			}
+
 			X509Certificate[] certificates = X509CertUtil.convertCertificates(keyStore.getCertificateChain(alias));
 
 			DefaultMutableTreeNode certificatesNode = new DefaultMutableTreeNode(
@@ -525,7 +530,13 @@ public class DProperties extends JEscDialog {
 		privateKeyNode.add(new DefaultMutableTreeNode(MessageFormat.format(
 				res.getString("DProperties.properties.Format"), keyFormat)));
 
-		String keyEncoded = "0x" + new BigInteger(1, privateKey.getEncoded()).toString(16).toUpperCase();
+		String keyEncoded;
+		byte[] encodedKey = privateKey.getEncoded();
+		if (encodedKey != null) {
+			keyEncoded = "0x" + new BigInteger(1, privateKey.getEncoded()).toString(16).toUpperCase();
+		} else {
+			keyEncoded = "*****";
+		}
 
 		privateKeyNode.add(new DefaultMutableTreeNode(MessageFormat.format(
 				res.getString("DProperties.properties.Encoded"), keyEncoded)));


### PR DESCRIPTION
The SmartCard-HSM supports Card-Verifiable-Certificates (CVCs) as defined in BSI TR-03110. Those are provided at the JCE Provider interface as subtype of java.security.cert.Certificate.

This PR adds a method to determine if the certificate is supported by keystore-explorer or not. If it is not supported, then the alias is silently ignored. Please check if there are other X509 Certificate types that need to be handled by this routine.

This PR also disables dumping the private key, if it's values is not provided by the JCE Provider (which is the case for hardware based private keys).