### PR TITLE
Added support for new QCStatement types.

### DIFF
--- a/kse/src/net/sf/keystore_explorer/crypto/x509/QcStatementType.java
+++ b/kse/src/net/sf/keystore_explorer/crypto/x509/QcStatementType.java
@@ -35,7 +35,9 @@ public enum QcStatementType {
 	QC_COMPLIANCE("0.4.0.1862.1.1", "QCCompliance"),
 	QC_EU_LIMIT_VALUE("0.4.0.1862.1.2", "QCEuLimitValue"),
 	QC_RETENTION_PERIOD("0.4.0.1862.1.3", "QCRetentionPeriod"),
-	QC_SSCD("0.4.0.1862.1.4", "QCSSCD");
+	QC_SSCD("0.4.0.1862.1.4", "QCSSCD"),
+	QC_PDS("0.4.0.1862.1.5", "QCPDS"),
+	QC_TYPE("0.4.0.1862.1.6", "QCType");
 
 	// @formatter:on
 

--- a/kse/src/net/sf/keystore_explorer/crypto/x509/X509Ext.java
+++ b/kse/src/net/sf/keystore_explorer/crypto/x509/X509Ext.java
@@ -124,6 +124,7 @@ import org.bouncycastle.asn1.DERBitString;
 import org.bouncycastle.asn1.DERGeneralString;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.DERPrintableString;
+import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.isismtt.x509.AdmissionSyntax;
 import org.bouncycastle.asn1.isismtt.x509.Admissions;
 import org.bouncycastle.asn1.isismtt.x509.DeclarationOfMajority;
@@ -2128,42 +2129,74 @@ public class X509Ext {
 			sb.append(NEWLINE);
 
 			QcStatementType qcStatementType = QcStatementType.resolveOid(statementId.getId());
-			switch (qcStatementType) {
-			case QC_SYNTAX_V1:
-			case QC_SYNTAX_V2:
-				SemanticsInformation semanticsInfo = SemanticsInformation.getInstance(statementInfo);
-				sb.append(getSemanticInformationValueString(qcStatementType, semanticsInfo, indentLevel));
-				break;
-			case QC_COMPLIANCE:
+			if (qcStatementType != null) {
+				switch (qcStatementType) {
+				case QC_SYNTAX_V1:
+				case QC_SYNTAX_V2:
+					SemanticsInformation semanticsInfo = SemanticsInformation.getInstance(statementInfo);
+					sb.append(getSemanticInformationValueString(qcStatementType, semanticsInfo, indentLevel));
+					break;
+				case QC_COMPLIANCE:
+					// no statementInfo
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(res.getString(QcStatementType.QC_COMPLIANCE.getResKey()));
+					sb.append(NEWLINE);
+					break;
+				case QC_EU_LIMIT_VALUE:
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(res.getString(QcStatementType.QC_EU_LIMIT_VALUE.getResKey()));
+					sb.append(NEWLINE);
+					sb.append(getMonetaryValueStringValue(statementInfo, indentLevel + 1));
+					break;
+				case QC_RETENTION_PERIOD:
+					ASN1Integer asn1Integer = ASN1Integer.getInstance(statementInfo);
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(MessageFormat.format(res.getString(QcStatementType.QC_RETENTION_PERIOD.getResKey()),
+							asn1Integer.getValue().toString()));
+					sb.append(NEWLINE);
+					break;
+				case QC_SSCD:
+					// no statementInfo
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(res.getString(QcStatementType.QC_SSCD.getResKey()));
+					sb.append(NEWLINE);
+					break;
+				case QC_PDS:
+					ASN1Sequence pdsLocations = ASN1Sequence.getInstance(statementInfo);
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(res.getString(QcStatementType.QC_PDS.getResKey()));
+					for (ASN1Encodable pdsLoc : pdsLocations) {
+						sb.append(NEWLINE);
+						sb.append(INDENT.toString(indentLevel + 1));
+						DLSequence pds = (DLSequence) pdsLoc;
+						sb.append(MessageFormat.format(res.getString("QCPDS.locations"), pds.getObjectAt(1), pds.getObjectAt(0)));
+					}
+					sb.append(NEWLINE);
+					break;
+				case QC_TYPE:
+					sb.append(INDENT.toString(indentLevel));
+					sb.append(res.getString(QcStatementType.QC_TYPE.getResKey()));
+					ASN1Sequence qcTypes = ASN1Sequence.getInstance(statementInfo);
+					for (ASN1Encodable type : qcTypes) {
+						sb.append(NEWLINE);
+						sb.append(INDENT.toString(indentLevel + 1));
+						sb.append(ObjectIdUtil.toString((ASN1ObjectIdentifier) type));
+					}
+					sb.append(NEWLINE);
+				}
+			} else {
 				// no statementInfo
 				sb.append(INDENT.toString(indentLevel));
-				sb.append(res.getString(QcStatementType.QC_COMPLIANCE.getResKey()));
+				sb.append(statementId.getId());
+				sb.append(statementInfo.toString());
 				sb.append(NEWLINE);
-				break;
-			case QC_EU_LIMIT_VALUE:
-				sb.append(INDENT.toString(indentLevel));
-				sb.append(res.getString(QcStatementType.QC_EU_LIMIT_VALUE.getResKey()));
-				sb.append(NEWLINE);
-				sb.append(getMonetaryValueStringValue(statementInfo, indentLevel + 1));
-				break;
-			case QC_RETENTION_PERIOD:
-				ASN1Integer asn1Integer = ASN1Integer.getInstance(statementInfo);
-				sb.append(INDENT.toString(indentLevel));
-				sb.append(MessageFormat.format(res.getString(QcStatementType.QC_RETENTION_PERIOD.getResKey()),
-						asn1Integer.getValue().toString()));
-				sb.append(NEWLINE);
-				break;
-			case QC_SSCD:
-				// no statementInfo
-				sb.append(INDENT.toString(indentLevel));
-				sb.append(res.getString(QcStatementType.QC_SSCD.getResKey()));
-				sb.append(NEWLINE);
-				break;
 			}
 		}
 
 		return sb.toString();
+
 	}
+
 
 	private String getSemanticInformationValueString(QcStatementType qcStatementType, SemanticsInformation
 			semanticsInfo, int baseIndentLevel) throws IOException {

--- a/kse/src/net/sf/keystore_explorer/crypto/x509/resources.properties
+++ b/kse/src/net/sf/keystore_explorer/crypto/x509/resources.properties
@@ -418,6 +418,12 @@ QCEuLimitValue.Currency=Currency: {0}
 QCEuLimitValue.Exponent=Exponent: {0}
 QCRetentionPeriod=QC Retention Period: {0}
 QCSSCD=QC Secure Signature Creation Device
+QCPDS=QC PKI Disclosure Statements
+QCPDS.locations={0}: <a href="{1}">{1}</a>
+QCType=QC Type
+QCType.Sign=eSign
+QCType.Seal=eSeal
+QCType.Web=Web
 
 # MSCaVersion strings
 MSCaVersion.CertIndex=Certificate Index: {0}

--- a/kse/src/net/sf/keystore_explorer/utilities/oid/ObjectIdUtil.java
+++ b/kse/src/net/sf/keystore_explorer/utilities/oid/ObjectIdUtil.java
@@ -382,6 +382,11 @@ public class ObjectIdUtil {
 		oidToNameMapping.put("0.4.0.1862.1.2", "EtsiQcsLimitValue");
 		oidToNameMapping.put("0.4.0.1862.1.3", "EtsiQcsRetentionPeriod");
 		oidToNameMapping.put("0.4.0.1862.1.4", "EtsiQcsQcSSCD");
+		oidToNameMapping.put("0.4.0.1862.1.5", "EtsiQcsQcPSD");
+		oidToNameMapping.put("0.4.0.1862.1.6", "EtsiQcsQcType");
+		oidToNameMapping.put("0.4.0.1862.1.6.1", "EtsiQctEsign");
+		oidToNameMapping.put("0.4.0.1862.1.6.2", "EtsiQctEseal");
+		oidToNameMapping.put("0.4.0.1862.1.6.3", "EtsiQctWeb");
 		oidToNameMapping.put("0.9.2342.19200300.100.1.1", "UserID");
 		oidToNameMapping.put("0.9.2342.19200300.100.1.3", "Rfc822Mailbox");
 		oidToNameMapping.put("0.9.2342.19200300.100.1.25", "DomainComponent");


### PR DESCRIPTION
Adressing issue #71.

 * QCPDS: PKI Disclosure Statements, composed of url and language.
 * QCType: eSign, eSeal or Web certificate.

    The presence of those elements threw exceptions because they weren't interpreted correctly.

 * A condition has been added as well to avoid throwing an exception if unkown "qcStatementType" are found (qcStatementType would be null during the 'case' evaluation).