### PR TITLE
Change DSA maximum key size to 2048 bits

### DIFF
--- a/kse/src/net/sf/keystore_explorer/crypto/keypair/KeyPairType.java
+++ b/kse/src/net/sf/keystore_explorer/crypto/keypair/KeyPairType.java
@@ -25,7 +25,7 @@ package net.sf.keystore_explorer.crypto.keypair;
  */
 public enum KeyPairType {
 	RSA("RSA", "1.2.840.113549.1.1.1", 512, 16384, 8),
-	DSA("DSA", "1.2.840.10040.4.1", 512, 1024, 64),
+	DSA("DSA", "1.2.840.10040.4.1", 512, 2048, 64),
 	EC("EC", "1.2.840.10045.2.1", 160, 571, 32);
 
 	private String jce;


### PR DESCRIPTION
KSE currently only supports 1024-bit DSA. This pull request will change the DSA maximum key size to 2048 bits, as Symantec is now using this key size.