### PR TITLE
Added support for Bouncy Castle's BCFKS keystore

### DIFF
--- a/kse/build.gradle
+++ b/kse/build.gradle
@@ -113,7 +113,7 @@ compileJava {
 }
 
 dependencies {
-	compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.58'
+	compile group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.59'
 	compile group: 'net.java.dev.jna', name: 'jna', version: '4.1.0'
 	compile group: 'commons-io', name: 'commons-io', version: '2.6'
 	compile group: 'javax.help', name: 'javahelp', version: '2.0.05'

--- a/kse/src/org/kse/crypto/ecc/EccUtil.java
+++ b/kse/src/org/kse/crypto/ecc/EccUtil.java
@@ -98,7 +98,8 @@ public class EccUtil {
 	public static boolean isBouncyCastleKeyStore(KeyStoreType keyStoreType) {
 		return (keyStoreType == KeyStoreType.BKS
 				|| keyStoreType == KeyStoreType.BKS_V1
-				|| keyStoreType == KeyStoreType.UBER);
+				|| keyStoreType == KeyStoreType.UBER
+				|| keyStoreType == KeyStoreType.BCFKS);
 	}
 
 	/**

--- a/kse/src/org/kse/crypto/filetype/CryptoFileType.java
+++ b/kse/src/org/kse/crypto/filetype/CryptoFileType.java
@@ -41,6 +41,9 @@ public enum CryptoFileType {
 	/** BKS KeyStore */
 	BKS_KS("CryptoFileType.BksKs"),
 
+	/** BCFKS FIPS KeyStore */
+	BCFKS_KS("CryptoFileType.BcfKs"),
+
 	/** UBER KeyStore */
 	UBER_KS("CryptoFileType.UberKs"),
 

--- a/kse/src/org/kse/crypto/filetype/CryptoFileUtil.java
+++ b/kse/src/org/kse/crypto/filetype/CryptoFileUtil.java
@@ -32,6 +32,7 @@ import static org.kse.crypto.filetype.CryptoFileType.UNENC_PKCS8_PVK;
 import static org.kse.crypto.filetype.CryptoFileType.UNKNOWN;
 import static org.kse.crypto.keystore.KeyStoreType.BKS;
 import static org.kse.crypto.keystore.KeyStoreType.BKS_V1;
+import static org.kse.crypto.keystore.KeyStoreType.BCFKS;
 import static org.kse.crypto.keystore.KeyStoreType.JCEKS;
 import static org.kse.crypto.keystore.KeyStoreType.JKS;
 import static org.kse.crypto.keystore.KeyStoreType.PKCS12;
@@ -49,6 +50,7 @@ import org.bouncycastle.asn1.ASN1Encodable;
 import org.bouncycastle.asn1.ASN1Integer;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DLSequence;
 import org.kse.crypto.csr.CsrType;
 import org.kse.crypto.csr.pkcs10.Pkcs10Util;
 import org.kse.crypto.csr.spkac.Spkac;
@@ -277,7 +279,9 @@ public class CryptoFileUtil {
 					if (version.getValue().intValue() == 3) {
 						return PKCS12;
 					}
-				}
+				} else if(firstComponent instanceof DLSequence){
+                    return BCFKS;
+                }
 			}
 		}
 

--- a/kse/src/org/kse/crypto/filetype/resources.properties
+++ b/kse/src/org/kse/crypto/filetype/resources.properties
@@ -26,6 +26,7 @@ CryptoFileType.Pkcs12Ks=PKCS #12 KeyStore
 CryptoFileType.BksV1Ks=BKS Version 1 KeyStore
 CryptoFileType.BksKs=BKS KeyStore
 CryptoFileType.UberKs=UBER KeyStore
+CryptoFileType.BcfKs=BCFKS KeyStore
 CryptoFileType.Certificate=Certificate
 CryptoFileType.Pkcs10Csr=PKCS #10 Certificate Signing Request (CSR)
 CryptoFileType.SpkacCsr=SPKAC Certificate Signing Request (CSR)

--- a/kse/src/org/kse/crypto/keystore/KeyStoreType.java
+++ b/kse/src/org/kse/crypto/keystore/KeyStoreType.java
@@ -25,6 +25,7 @@ import static org.kse.crypto.filetype.CryptoFileType.JCEKS_KS;
 import static org.kse.crypto.filetype.CryptoFileType.JKS_KS;
 import static org.kse.crypto.filetype.CryptoFileType.PKCS12_KS;
 import static org.kse.crypto.filetype.CryptoFileType.UBER_KS;
+import static org.kse.crypto.filetype.CryptoFileType.BCFKS_KS;
 
 import java.util.ResourceBundle;
 
@@ -46,7 +47,8 @@ public enum KeyStoreType {
 	KEYCHAIN("KeychainStore", "KeyStoreType.AppleKeyChain", false, null),
 	MS_CAPI_PERSONAL("Windows-MY", "KeyStoreType.MscapiPersonalCerts", false, null),
 	MS_CAPI_ROOT("Windows-ROOT", "Windows Root Certificates", false, null),
-	PKCS11("PKCS11", "KeyStoreType.Pkcs11", false, null);
+	PKCS11("PKCS11", "KeyStoreType.Pkcs11", false, null),
+	BCFKS("BCFKS", "KeyStoreType.Bcfks", true, BCFKS_KS);
 
 	private static ResourceBundle res = ResourceBundle.getBundle("org/kse/crypto/keystore/resources");
 	private String jce;
@@ -112,7 +114,7 @@ public enum KeyStoreType {
 	 * @return True, if secret key entries are supported by this KeyStore type
 	 */
 	public boolean supportsKeyEntries() {
-		return this == JCEKS || this == BKS || this == BKS_V1 || this == UBER;
+		return this == JCEKS || this == BKS || this == BKS_V1 || this == UBER || this == BCFKS;
 	}
 
 	/**

--- a/kse/src/org/kse/crypto/keystore/KeyStoreUtil.java
+++ b/kse/src/org/kse/crypto/keystore/KeyStoreUtil.java
@@ -25,6 +25,7 @@ import static org.kse.crypto.SecurityProvider.MS_CAPI;
 import static org.kse.crypto.keypair.KeyPairType.EC;
 import static org.kse.crypto.keystore.KeyStoreType.BKS;
 import static org.kse.crypto.keystore.KeyStoreType.BKS_V1;
+import static org.kse.crypto.keystore.KeyStoreType.BCFKS;
 import static org.kse.crypto.keystore.KeyStoreType.KEYCHAIN;
 import static org.kse.crypto.keystore.KeyStoreType.UBER;
 
@@ -433,7 +434,7 @@ public final class KeyStoreUtil {
 
 	private static KeyStore getKeyStoreInstance(KeyStoreType keyStoreType) throws CryptoException {
 		try {
-			if (keyStoreType == BKS || keyStoreType == BKS_V1 || keyStoreType == UBER) {
+			if (keyStoreType == BKS || keyStoreType == BKS_V1 || keyStoreType == UBER || keyStoreType == BCFKS) {
 				if (Security.getProvider(BOUNCY_CASTLE.jce()) == null) {
 					throw new CryptoException(MessageFormat.format(res.getString("NoProvider.exception.message"),
 							BOUNCY_CASTLE.jce()));

--- a/kse/src/org/kse/crypto/keystore/resources.properties
+++ b/kse/src/org/kse/crypto/keystore/resources.properties
@@ -39,6 +39,7 @@ KeyStoreType.Jceks=JCEKS
 KeyStoreType.Pkcs12=PKCS #12
 KeyStoreType.BksV1=BKS-V1
 KeyStoreType.Bks=BKS
+KeyStoreType.Bcfks=BCFKS
 KeyStoreType.Uber=UBER
 KeyStoreType.AppleKeyChain=Apple Keychain
 KeyStoreType.MscapiPersonalCerts=Windows Personal Certificates

--- a/kse/src/org/kse/gui/FileChooserFactory.java
+++ b/kse/src/org/kse/gui/FileChooserFactory.java
@@ -41,6 +41,7 @@ public class FileChooserFactory {
 	public static final String JCEKS_EXT = "jceks";
 	public static final String BKS_EXT = "bks";
 	public static final String UBER_EXT = "uber";
+	public static final String BCFKS_EXT = "bcfks";
 	public static final String PKCS12_KEYSTORE_EXT_1 = "pfx";
 	public static final String PKCS12_KEYSTORE_EXT_2 = "p12";
 	public static final String X509_EXT_1 = "cer";
@@ -68,7 +69,7 @@ public class FileChooserFactory {
 
 	private static final String KEYSTORE_FILE_DESC = MessageFormat.format(
 			res.getString("FileChooserFactory.KeyStoreFiles"), KEYSTORE_EXT_1, KEYSTORE_EXT_2, JKS_EXT, JCEKS_EXT,
-			BKS_EXT, UBER_EXT);
+			BKS_EXT, UBER_EXT, BCFKS_EXT);
 
 	private static final String X509_FILE_DESC = MessageFormat.format(
 			res.getString("FileChooserFactory.CertificateFiles"), X509_EXT_1, X509_EXT_2);
@@ -143,7 +144,7 @@ public class FileChooserFactory {
 		chooser.addChoosableFileFilter(new FileExtFilter(new String[] { PKCS12_KEYSTORE_EXT_1, PKCS12_KEYSTORE_EXT_2 },
 				PKCS12_FILE_DESC));
 		chooser.addChoosableFileFilter(new FileExtFilter(new String[] { KEYSTORE_EXT_1, KEYSTORE_EXT_2, JKS_EXT,
-				JCEKS_EXT, BKS_EXT, UBER_EXT }, KEYSTORE_FILE_DESC));
+				JCEKS_EXT, BKS_EXT, UBER_EXT, BCFKS_EXT }, KEYSTORE_FILE_DESC));
 		return chooser;
 	}
 

--- a/kse/src/org/kse/gui/KseFrame.java
+++ b/kse/src/org/kse/gui/KseFrame.java
@@ -24,6 +24,7 @@ import static org.kse.crypto.keystore.KeyStoreType.BKS_V1;
 import static org.kse.crypto.keystore.KeyStoreType.JCEKS;
 import static org.kse.crypto.keystore.KeyStoreType.JKS;
 import static org.kse.crypto.keystore.KeyStoreType.PKCS12;
+import static org.kse.crypto.keystore.KeyStoreType.BCFKS;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -258,6 +259,7 @@ public final class KseFrame implements StatusBar {
 	private JRadioButtonMenuItem jrbmiChangeTypePkcs12;
 	private JRadioButtonMenuItem jrbmiChangeTypeBksV1;
 	private JRadioButtonMenuItem jrbmiChangeTypeBks;
+	private JRadioButtonMenuItem jrbmiChangeTypeBcfks;
 	private JRadioButtonMenuItem jrbmiChangeTypeUber;
 	private JMenuItem jmiSetPassword;
 	private JMenuItem jmiProperties;
@@ -331,6 +333,7 @@ public final class KseFrame implements StatusBar {
 	private JRadioButtonMenuItem jrbmiKeyStoreChangeTypePkcs12;
 	private JRadioButtonMenuItem jrbmiKeyStoreChangeTypeBksV1;
 	private JRadioButtonMenuItem jrbmiKeyStoreChangeTypeBks;
+	private JRadioButtonMenuItem jrbmiKeyStoreChangeTypeBcfks;
 	private JRadioButtonMenuItem jrbmiKeyStoreChangeTypeUber;
 	private JMenuItem jmiKeyStoreSetPassword;
 	private JMenuItem jmiKeyStoreProperties;
@@ -434,6 +437,7 @@ public final class KseFrame implements StatusBar {
 	private final ChangeTypeAction changeTypePkcs12Action = new ChangeTypeAction(this, KeyStoreType.PKCS12);
 	private final ChangeTypeAction changeTypeBksV1Action = new ChangeTypeAction(this, KeyStoreType.BKS_V1);
 	private final ChangeTypeAction changeTypeBksAction = new ChangeTypeAction(this, KeyStoreType.BKS);
+	private final ChangeTypeAction changeTypeBcfksAction = new ChangeTypeAction(this, KeyStoreType.BCFKS);
 	private final ChangeTypeAction changeTypeUberAction = new ChangeTypeAction(this, KeyStoreType.UBER);
 	private final PropertiesAction propertiesAction = new PropertiesAction(this);
 	private final PreferencesAction preferencesAction = new PreferencesAction(this);
@@ -902,6 +906,13 @@ public final class KseFrame implements StatusBar {
 				this);
 		jmChangeType.add(jrbmiChangeTypeBks);
 
+		jrbmiChangeTypeBcfks = new JRadioButtonMenuItem(changeTypeBcfksAction);
+		PlatformUtil.setMnemonic(jrbmiChangeTypeBcfks, res.getString("KseFrame.jrbmiChangeTypeBcfks.mnemonic").charAt(0));
+		jrbmiChangeTypeBcfks.setToolTipText(null);
+		new StatusBarChangeHandler(jrbmiChangeTypeBcfks, (String) changeTypeBcfksAction.getValue(Action.LONG_DESCRIPTION),
+				this);
+		jmChangeType.add(jrbmiChangeTypeBcfks);
+
 		jrbmiChangeTypeUber = new JRadioButtonMenuItem(changeTypeUberAction);
 		PlatformUtil.setMnemonic(jrbmiChangeTypeUber, res.getString("KseFrame.jrbmiChangeTypeUber.mnemonic").charAt(0));
 		jrbmiChangeTypeUber.setToolTipText(null);
@@ -914,6 +925,7 @@ public final class KseFrame implements StatusBar {
 		changeTypeGroup.add(jrbmiChangeTypeJceks);
 		changeTypeGroup.add(jrbmiChangeTypePkcs12);
 		changeTypeGroup.add(jrbmiChangeTypeBks);
+		changeTypeGroup.add(jrbmiChangeTypeBcfks);
 		changeTypeGroup.add(jrbmiChangeTypeBksV1);
 		changeTypeGroup.add(jrbmiChangeTypeUber);
 
@@ -1812,6 +1824,14 @@ public final class KseFrame implements StatusBar {
 				(String) changeTypeBksAction.getValue(Action.LONG_DESCRIPTION), this);
 		jmKeyStoreChangeType.add(jrbmiKeyStoreChangeTypeBks);
 
+		jrbmiKeyStoreChangeTypeBcfks = new JRadioButtonMenuItem(changeTypeBcfksAction);
+		PlatformUtil.setMnemonic(jrbmiKeyStoreChangeTypeBcfks, res.getString("KseFrame.jrbmiChangeTypeBcfks.mnemonic")
+				.charAt(0));
+		jrbmiKeyStoreChangeTypeBcfks.setToolTipText(null);
+		new StatusBarChangeHandler(jrbmiKeyStoreChangeTypeBcfks,
+				(String) changeTypeBcfksAction.getValue(Action.LONG_DESCRIPTION), this);
+		jmKeyStoreChangeType.add(jrbmiKeyStoreChangeTypeBcfks);
+
 		jrbmiKeyStoreChangeTypeUber = new JRadioButtonMenuItem(changeTypeUberAction);
 		PlatformUtil.setMnemonic(jrbmiKeyStoreChangeTypeUber, res.getString("KseFrame.jrbmiChangeTypeUber.mnemonic")
 				.charAt(0));
@@ -1826,6 +1846,7 @@ public final class KseFrame implements StatusBar {
 		changeTypeGroup.add(jrbmiKeyStoreChangeTypePkcs12);
 		changeTypeGroup.add(jrbmiKeyStoreChangeTypeBks);
 		changeTypeGroup.add(jrbmiKeyStoreChangeTypeBksV1);
+		changeTypeGroup.add(jrbmiKeyStoreChangeTypeBcfks);
 		changeTypeGroup.add(jrbmiKeyStoreChangeTypeUber);
 
 		jmiKeyStoreProperties = new JMenuItem(propertiesAction);
@@ -2605,6 +2626,9 @@ public final class KseFrame implements StatusBar {
 			} else if (type == BKS) {
 				jrbmiChangeTypeBks.setSelected(true);
 				jrbmiKeyStoreChangeTypeBks.setSelected(true);
+			} else if (type == BCFKS) {
+				jrbmiChangeTypeBcfks.setSelected(true);
+				jrbmiKeyStoreChangeTypeBcfks.setSelected(true);
 			} else {
 				jrbmiChangeTypeUber.setSelected(true);
 				jrbmiKeyStoreChangeTypeUber.setSelected(true);
@@ -2661,6 +2685,7 @@ public final class KseFrame implements StatusBar {
 		jrbmiChangeTypeJceks.setSelected(false);
 		jrbmiChangeTypePkcs12.setSelected(false);
 		jrbmiChangeTypeBks.setSelected(false);
+		jrbmiChangeTypeBcfks.setSelected(false);
 		jrbmiChangeTypeBksV1.setSelected(false);
 		jrbmiChangeTypeUber.setSelected(false);
 		jrbmiKeyStoreChangeTypeJks.setSelected(false);
@@ -2668,6 +2693,7 @@ public final class KseFrame implements StatusBar {
 		jrbmiKeyStoreChangeTypePkcs12.setSelected(false);
 		jrbmiKeyStoreChangeTypeBks.setSelected(false);
 		jrbmiKeyStoreChangeTypeBksV1.setSelected(false);
+		jrbmiKeyStoreChangeTypeBcfks.setSelected(false);
 		jrbmiKeyStoreChangeTypeUber.setSelected(false);
 
 		// Show Quick Start pane

--- a/kse/src/org/kse/gui/actions/ExamineClipboardAction.java
+++ b/kse/src/org/kse/gui/actions/ExamineClipboardAction.java
@@ -135,6 +135,7 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
 			case BKS_KS:
 			case BKS_V1_KS:
 			case UBER_KS:
+			case BCFKS_KS:
 			case UNKNOWN:
 			default:
 				JOptionPane.showMessageDialog(frame,

--- a/kse/src/org/kse/gui/actions/ExamineFileAction.java
+++ b/kse/src/org/kse/gui/actions/ExamineFileAction.java
@@ -116,6 +116,7 @@ public class ExamineFileAction extends KeyStoreExplorerAction {
 			case PKCS12_KS:
 			case BKS_KS:
 			case BKS_V1_KS:
+			case BCFKS_KS:
 			case UBER_KS:
 				openAction.openKeyStore(file);
 				break;

--- a/kse/src/org/kse/gui/actions/resources.properties
+++ b/kse/src/org/kse/gui/actions/resources.properties
@@ -417,7 +417,7 @@ OpenAction.TryAgain.Title=Try Again?
 # Messages
 OpenAction.NotFile.message=''{0}'' is not a file.
 OpenAction.NoOpenKeyStoreAlreadyOpen.message=The KeyStore ''{0}'' is already open.
-OpenAction.FileNotRecognisedType.message=''{0}'' is not a KeyStore of any of the following recognized types\:\nJCE, JCEKS, PKCS \#12, BKS or UBER.
+OpenAction.FileNotRecognisedType.message=''{0}'' is not a KeyStore of any of the following recognized types\:\nJCE, JCEKS, PKCS \#12, BKS, UBER or BCFKS.
 OpenAction.NoReadFile.message=Could not read from file ''{0}''.
 OpenAction.TryAgain.message=Do you want to try entering the password again?
 
@@ -557,7 +557,7 @@ AuthorityCertificatesAction.CaCertificatesKeyStorePassword.Title=CA Certificates
 AuthorityCertificatesAction.ProblemOpeningCaCertificatesKeyStore.Title=Problem Opening CA Certificates KeyStore
 
 # Messages
-AuthorityCertificatesAction.FileNotRecognisedType.message=''{0}'' is not a KeyStore of any of the following recognized types\:\nJCE, JCEKS, PKCS \#12, BKS or UBER.
+AuthorityCertificatesAction.FileNotRecognisedType.message=''{0}'' is not a KeyStore of any of the following recognized types\:\nJCE, JCEKS, PKCS \#12, BKS, UBER or BCFKS.
 AuthorityCertificatesAction.NoReadFile.message=Could not read from file ''{0}''.
 
 # Problems and causes
@@ -649,7 +649,7 @@ ExamineFileAction.EnterPassword.Title=Enter Password for ''{0}''
 
 # Messages
 ExamineFileAction.NotFile.message=''{0}'' is not a file.
-ExamineFileAction.UnknownFileType.message=''{0}'' is none of the following recognized file types\:\n - X.509 Certificate \n - CRL \n - CSR (PKCS#10 or SPKAC) \n - Private Key (OpenSSL or PKCS#8) \n - Public Key (OpenSSL) \n - KeyStore (JCEKS, JKS, PKCS#12, BKS or UBER)
+ExamineFileAction.UnknownFileType.message=''{0}'' is none of the following recognized file types\:\n - X.509 Certificate \n - CRL \n - CSR (PKCS#10 or SPKAC) \n - Private Key (OpenSSL or PKCS#8) \n - Public Key (OpenSSL) \n - KeyStore (JCEKS, JKS, PKCS#12, BKS, UBER or BCFKS)
 ExamineFileAction.NoReadFile.message=Could not read from file ''{0}''.
 
 # Problems and causes

--- a/kse/src/org/kse/gui/dialogs/DNewKeyStoreType.java
+++ b/kse/src/org/kse/gui/dialogs/DNewKeyStoreType.java
@@ -65,6 +65,7 @@ public class DNewKeyStoreType extends JEscDialog {
 	private JRadioButton jrbBksV1KeyStore;
 	private JRadioButton jrbBksKeyStore;
 	private JRadioButton jrbUberKeyStore;
+	private JRadioButton jrbBcfksKeyStore;
 	private JPanel jpButtons;
 	private JButton jbOK;
 	private JButton jbCancel;
@@ -112,6 +113,10 @@ public class DNewKeyStoreType extends JEscDialog {
 		PlatformUtil.setMnemonic(jrbUberKeyStore, res.getString("DNewKeyStoreType.jrbUberKeyStore.mnemonic").charAt(0));
 		jrbUberKeyStore.setToolTipText(res.getString("DNewKeyStoreType.jrbUberKeyStore.tooltip"));
 
+        jrbBcfksKeyStore = new JRadioButton(res.getString("DNewKeyStoreType.jrbBcfksKeyStore.text"));
+        PlatformUtil.setMnemonic(jrbBcfksKeyStore, res.getString("DNewKeyStoreType.jrbBcfksKeyStore.mnemonic").charAt(0));
+        jrbBcfksKeyStore.setToolTipText(res.getString("DNewKeyStoreType.jrbBcfksKeyStore.tooltip"));
+
 		ButtonGroup keyStoreTypes = new ButtonGroup();
 
 		keyStoreTypes.add(jrbJceksKeyStore);
@@ -120,8 +125,9 @@ public class DNewKeyStoreType extends JEscDialog {
 		keyStoreTypes.add(jrbBksV1KeyStore);
 		keyStoreTypes.add(jrbBksKeyStore);
 		keyStoreTypes.add(jrbUberKeyStore);
+		keyStoreTypes.add(jrbBcfksKeyStore);
 
-		jpKeyStoreType = new JPanel(new GridLayout(7, 1));
+		jpKeyStoreType = new JPanel(new GridLayout(8, 1));
 		jpKeyStoreType.setBorder(new CompoundBorder(new EmptyBorder(5, 5, 5, 5), new CompoundBorder(new EtchedBorder(),
 				new EmptyBorder(5, 5, 5, 5))));
 
@@ -132,6 +138,7 @@ public class DNewKeyStoreType extends JEscDialog {
 		jpKeyStoreType.add(jrbBksV1KeyStore);
 		jpKeyStoreType.add(jrbBksKeyStore);
 		jpKeyStoreType.add(jrbUberKeyStore);
+		jpKeyStoreType.add(jrbBcfksKeyStore);
 
 		jbOK = new JButton(res.getString("DNewKeyStoreType.jbOK.text"));
 		jbOK.addActionListener(new ActionListener() {
@@ -199,6 +206,8 @@ public class DNewKeyStoreType extends JEscDialog {
 			keyStoreType = KeyStoreType.BKS_V1;
 		} else if (jrbBksKeyStore.isSelected()) {
 			keyStoreType = KeyStoreType.BKS;
+		} else if (jrbBcfksKeyStore.isSelected()) {
+			keyStoreType = KeyStoreType.BCFKS;
 		} else {
 			keyStoreType = KeyStoreType.UBER;
 		}

--- a/kse/src/org/kse/gui/dialogs/resources.properties
+++ b/kse/src/org/kse/gui/dialogs/resources.properties
@@ -244,6 +244,7 @@ DNewKeyStoreType.jrbPkcs12KeyStore.text=PKCS #12
 DNewKeyStoreType.jrbBksV1KeyStore.text=BKS-V1
 DNewKeyStoreType.jrbBksKeyStore.text=BKS
 DNewKeyStoreType.jrbUberKeyStore.text=UBER
+DNewKeyStoreType.jrbBcfksKeyStore.text=BCFKS
 DNewKeyStoreType.jbOK.text=OK
 DNewKeyStoreType.jbCancel.text=Cancel
 
@@ -254,6 +255,7 @@ DNewKeyStoreType.jrbPkcs12KeyStore.mnemonic=P
 DNewKeyStoreType.jrbBksV1KeyStore.mnemonic=V
 DNewKeyStoreType.jrbBksKeyStore.mnemonic=B
 DNewKeyStoreType.jrbUberKeyStore.mnemonic=U
+DNewKeyStoreType.jrbBcfksKeyStore.mnemonic=F
 
 # Tool tip text
 DNewKeyStoreType.jrbJceksKeyStore.tooltip=Java Cryptography Extension KeyStore (Oracle's advanced KeyStore format)
@@ -262,6 +264,7 @@ DNewKeyStoreType.jrbPkcs12KeyStore.tooltip=Public-Key Cryptography Standards #12
 DNewKeyStoreType.jrbBksV1KeyStore.tooltip=Bouncy Castle KeyStore (Bouncy Castle's version of JKS) Version 1
 DNewKeyStoreType.jrbBksKeyStore.tooltip=Bouncy Castle KeyStore (Bouncy Castle's version of JKS)
 DNewKeyStoreType.jrbUberKeyStore.tooltip=Bouncy Castle UBER KeyStore (More secure version of BKS)
+DNewKeyStoreType.jrbBcfksKeyStore.tooltip=Bouncy Castle FIPS KeyStore
 
 ############################################################################
 # DViewKeyPair Resources

--- a/kse/src/org/kse/gui/resources.properties
+++ b/kse/src/org/kse/gui/resources.properties
@@ -126,6 +126,7 @@ KseFrame.jrbmiChangeTypeJceks.mnemonic=e
 KseFrame.jrbmiChangeTypePkcs12.mnemonic=k
 KseFrame.jrbmiChangeTypeBksV1.mnemonic=v
 KseFrame.jrbmiChangeTypeBks.mnemonic=b
+KseFrame.jrbmiChangeTypeBcfks.mnemonic=f
 KseFrame.jrbmiChangeTypeUber.mnemonic=u
 KseFrame.jmiProperties.mnemonic=p
 KseFrame.jmiPreferences.mnemonic=r
@@ -261,7 +262,7 @@ KeyStoreTableCellRend.CertUnexpiredEntry.image=images/table/cert_unexpired_entry
 ############################################################################
 
 # File description strings
-FileChooserFactory.KeyStoreFiles=KeyStore Files (*.{0};*.{1};*.{2};*.{3};*.{4};*.{5})
+FileChooserFactory.KeyStoreFiles=KeyStore Files (*.{0};*.{1};*.{2};*.{3};*.{4};*.{5};*.{6})
 FileChooserFactory.CertificateFiles=Certificate Files (*.{0};*.{1})
 FileChooserFactory.Pkcs7Files=PKCS #7 Certificates Files (*.{0};*.{1})
 FileChooserFactory.PkiPathFiles=PKI Path Certificate Files (*.{0})


### PR DESCRIPTION
This should resolve issue #113 
Updated the version of BouncyCastle to the latest that now provides the BCFKS keystore.
Plumbed support for BCFKS throughout keystore-explorer