### PR TITLE
Bugfix for NPE when reading the tips and tipsText has no member

### DIFF
--- a/kse/src/org/kse/gui/tipoftheday/DTipOfTheDay.java
+++ b/kse/src/org/kse/gui/tipoftheday/DTipOfTheDay.java
@@ -251,7 +251,7 @@ public class DTipOfTheDay extends JEscDialog {
 
 		// Look for all properties "<tip prefix>x" where x is a sequential 0-index
 		try {
-			for (int i = 0; i < tipsText.length; i++) {
+			for (int i = 0; ; i++) {
 				String tip = tips.getString(tipPrefix + i);
 				tipList.add(tip);
 			}


### PR DESCRIPTION
Sorry - I didn't make a topic branch. Hope it is okay.
The NPE appear only when I show/read the Tiptext.