### PR TITLE
Allow to select multiple entries and copy/paste or delete them

### DIFF
--- a/kse/src/org/kse/gui/KseFrame.java
+++ b/kse/src/org/kse/gui/KseFrame.java
@@ -53,6 +53,7 @@ import java.security.Provider;
 import java.security.cert.Certificate;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.ResourceBundle;
 
 import javax.swing.AbstractAction;
@@ -1525,7 +1526,7 @@ public final class KseFrame implements StatusBar {
 		jtKeyStore.setRowSorter(sorter);
 
 		jtKeyStore.setShowGrid(false);
-		jtKeyStore.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+		jtKeyStore.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
 		jtKeyStore.getTableHeader().setReorderingAllowed(false);
 		jtKeyStore.setAutoResizeMode(autoResizeMode);
 		jtKeyStore.setRowHeight(Math.max(18, jtKeyStore.getRowHeight())); // min. height of 18 because of 16x16 icons
@@ -2511,27 +2512,63 @@ public final class KseFrame implements StatusBar {
 		return (String) jtKeyStore.getValueAt(row, 3);
 	}
 
+	/**
+	 * Get the aliases of all entries currently selected in the KeyStore
+	 *
+	 * @return Selected aliases (may be an empty array, but never null)
+	 */
+	public String[] getSelectedEntryAliases() {
+		JTable jtKeyStore = getActiveKeyStoreTable();
+		int[] rows = jtKeyStore.getSelectedRows();
+
+		String[] retval = new String[rows.length];
+
+		for (int i = 0; i < rows.length; i++) {
+			retval[i] = (String) jtKeyStore.getValueAt(rows[i], 3);
+		}
+
+		return retval;
+	}
+
 	private String getNextEntrysAlias() {
 		JTable jtKeyStore = getActiveKeyStoreTable();
-		int row = jtKeyStore.getSelectedRow();
+		int[] rows = jtKeyStore.getSelectedRows();
 
 		// no row selected
-		if (row == -1) {
+		if (rows.length == 0) {
 			return null;
 		}
 
-
 		int rowCount = jtKeyStore.getModel().getRowCount();
-		if (rowCount < 2) {
-			// only one row
+		if ( rows.length == rowCount) {
+			// all rows are selected
 			return null;
 		} else {
-			if (row < (rowCount - 1)) {
-				// selected row is not the last one, return alias of next row
-				return (String) jtKeyStore.getValueAt(row + 1, 3);
+			int idx;
+			int max = Arrays.stream(rows).max().getAsInt();
+			if (max < (rowCount - 1)) {
+				// last selected row is not the last one, return alias of next row
+				idx = max + 1;
 			} else {
-				// selected row is the last one, return alias of previous row
-				return (String) jtKeyStore.getValueAt(row - 1, 3);
+				// last selected row is the last one, return alias of previous row
+				int min = Arrays.stream(rows).min().getAsInt();
+				if (min >= 1) {
+					idx = min - 1;
+				} else {
+					idx = -1;
+					Arrays.sort(rows);
+					for (int i = rows.length - 1; i >= 1; i--) {
+						if (rows[i] - rows[i - 1] > 1) { // found a gap
+							idx = rows[i] - 1;
+							break;
+						}
+					}
+				}
+			}
+			if (idx >= 0) {
+				return (String) jtKeyStore.getValueAt(idx, 3);
+			} else {
+				return null;
 			}
 		}
 	}

--- a/kse/src/org/kse/gui/KseFrame.java
+++ b/kse/src/org/kse/gui/KseFrame.java
@@ -114,6 +114,7 @@ import org.kse.gui.actions.CutKeyPairAction;
 import org.kse.gui.actions.CutTrustedCertificateAction;
 import org.kse.gui.actions.DeleteKeyAction;
 import org.kse.gui.actions.DeleteKeyPairAction;
+import org.kse.gui.actions.DeleteMultipleEntriesAction;
 import org.kse.gui.actions.DeleteTrustedCertificateAction;
 import org.kse.gui.actions.DetectFileTypeAction;
 import org.kse.gui.actions.ExamineClipboardAction;
@@ -488,6 +489,9 @@ public final class KseFrame implements StatusBar {
 	private final SetKeyPairPasswordAction setKeyPairPasswordAction = new SetKeyPairPasswordAction(this);
 	private final DeleteKeyPairAction deleteKeyPairAction = new DeleteKeyPairAction(this);
 	private final RenameKeyPairAction renameKeyPairAction = new RenameKeyPairAction(this);
+
+	private final DeleteMultipleEntriesAction deleteMultipleEntriesAction = new DeleteMultipleEntriesAction(this);
+
 	private final TrustedCertificateDetailsAction trustedCertificateDetailsAction = new TrustedCertificateDetailsAction(
 			this);
 	private final TrustedCertificatePublicKeyDetailsAction trustedCertificatePublicKeyDetailsAction = new TrustedCertificatePublicKeyDetailsAction(
@@ -1635,12 +1639,18 @@ public final class KseFrame implements StatusBar {
 		int nrEntriesBeforeDeletion = getNumberOfEntries();
 
 		try {
-			if (KeyStoreUtil.isKeyPairEntry(alias, keyStore)) {
-				deleteKeyPairAction.deleteSelectedEntry();
-			} else if (KeyStoreUtil.isTrustedCertificateEntry(alias, keyStore)) {
-				deleteTrustedCertificateAction.deleteSelectedEntry();
+			String[] aliases = getSelectedEntryAliases();
+			if (aliases.length == 1) {
+				// if only one entry is selected, use the specific action as it displays a nice warning dialog
+				if (KeyStoreUtil.isKeyPairEntry(alias, keyStore)) {
+					deleteKeyPairAction.deleteSelectedEntry();
+				} else if (KeyStoreUtil.isTrustedCertificateEntry(alias, keyStore)) {
+					deleteTrustedCertificateAction.deleteSelectedEntry();
+				} else {
+					deleteKeyAction.deleteSelectedEntry();
+				}
 			} else {
-				deleteKeyAction.deleteSelectedEntry();
+				deleteMultipleEntriesAction.deleteSelectedEntries();
 			}
 
 			// if one entry was deleted, select next entry

--- a/kse/src/org/kse/gui/KseFrame.java
+++ b/kse/src/org/kse/gui/KseFrame.java
@@ -52,9 +52,7 @@ import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.cert.Certificate;
 import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.ResourceBundle;
+import java.util.*;
 
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -1655,7 +1653,7 @@ public final class KseFrame implements StatusBar {
 
 			// if one entry was deleted, select next entry
 			if ((getNumberOfEntries() < nrEntriesBeforeDeletion) && (nextAlias != null)) {
-				setSelectedEntryByAlias(nextAlias);
+				setSelectedEntriesByAliases(nextAlias);
 			}
 		} catch (Exception ex) {
 			DError.displayError(frame, ex);
@@ -2588,14 +2586,16 @@ public final class KseFrame implements StatusBar {
 		return jtKeyStore.getModel().getRowCount();
 	}
 
-	public void setSelectedEntryByAlias(String alias) {
+	public void setSelectedEntriesByAliases(String... aliases) {
 		JTable jtKeyStore = getActiveKeyStoreTable();
 		jtKeyStore.requestFocusInWindow();
 
+		ListSelectionModel selectionModel = jtKeyStore.getSelectionModel();
+		selectionModel.clearSelection();
+		Set<String> aliasesToSelect = new HashSet<>(Arrays.asList(aliases));
 		for (int i = 0; i < jtKeyStore.getRowCount(); i++) {
-			if (alias.equals(jtKeyStore.getValueAt(i, 3))) {
-				jtKeyStore.setRowSelectionInterval(i, i);
-				break;
+			if (aliasesToSelect.contains(jtKeyStore.getValueAt(i, 3))) {
+				selectionModel.addSelectionInterval(i, i);
 			}
 		}
 	}
@@ -2620,13 +2620,13 @@ public final class KseFrame implements StatusBar {
 		// Reload KeyStore in table if it has changed
 		if (keyStoreContentsChanged) {
 			try {
-				String selectedAlias = getSelectedEntryAlias();
+				String[] selectedAliases = getSelectedEntryAliases();
 
 				((KeyStoreTableModel) getActiveKeyStoreTable().getModel()).load(history);
 
 				// Loading the model loses the selected entry - preserve it
-				if (selectedAlias != null) {
-					setSelectedEntryByAlias(selectedAlias);
+				if (selectedAliases.length > 0) {
+					setSelectedEntriesByAliases(selectedAliases);
 				}
 			} catch (GeneralSecurityException | CryptoException ex) {
 				DError.displayError(frame, ex);

--- a/kse/src/org/kse/gui/KseFrame.java
+++ b/kse/src/org/kse/gui/KseFrame.java
@@ -2530,7 +2530,7 @@ public final class KseFrame implements StatusBar {
 		return retval;
 	}
 
-	private String getNextEntrysAlias() {
+	public String getNextEntrysAlias() {
 		JTable jtKeyStore = getActiveKeyStoreTable();
 		int[] rows = jtKeyStore.getSelectedRows();
 
@@ -2578,7 +2578,7 @@ public final class KseFrame implements StatusBar {
 		return jtKeyStore.getModel().getRowCount();
 	}
 
-	private void setSelectedEntryByAlias(String alias) {
+	public void setSelectedEntryByAlias(String alias) {
 		JTable jtKeyStore = getActiveKeyStoreTable();
 		jtKeyStore.requestFocusInWindow();
 

--- a/kse/src/org/kse/gui/actions/CutAction.java
+++ b/kse/src/org/kse/gui/actions/CutAction.java
@@ -88,7 +88,7 @@ public class CutAction extends KeyStoreExplorerAction implements HistoryAction {
 			Buffer.populate(bufferEntries);
 			kseFrame.updateControls(true);
 			if (nextAlias != null) {
-				kseFrame.setSelectedEntryByAlias(nextAlias);
+				kseFrame.setSelectedEntriesByAliases(nextAlias);
 			}
 		}
 	}

--- a/kse/src/org/kse/gui/actions/CutAction.java
+++ b/kse/src/org/kse/gui/actions/CutAction.java
@@ -81,11 +81,15 @@ public class CutAction extends KeyStoreExplorerAction implements HistoryAction {
 	 */
 	@Override
 	protected void doAction() {
+		String nextAlias = kseFrame.getNextEntrysAlias();
 		List<BufferEntry> bufferEntries = bufferSelectedEntries();
 
 		if (bufferEntries != null && !bufferEntries.isEmpty()) {
 			Buffer.populate(bufferEntries);
 			kseFrame.updateControls(true);
+			if (nextAlias != null) {
+				kseFrame.setSelectedEntryByAlias(nextAlias);
+			}
 		}
 	}
 

--- a/kse/src/org/kse/gui/actions/CutAction.java
+++ b/kse/src/org/kse/gui/actions/CutAction.java
@@ -24,6 +24,8 @@ import java.security.Key;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
@@ -79,74 +81,79 @@ public class CutAction extends KeyStoreExplorerAction implements HistoryAction {
 	 */
 	@Override
 	protected void doAction() {
-		BufferEntry bufferEntry = bufferSelectedEntry();
+		List<BufferEntry> bufferEntries = bufferSelectedEntries();
 
-		if (bufferEntry != null) {
-			Buffer.populate(bufferEntry);
+		if (bufferEntries != null && !bufferEntries.isEmpty()) {
+			Buffer.populate(bufferEntries);
 			kseFrame.updateControls(true);
 		}
 	}
 
-	private BufferEntry bufferSelectedEntry() {
+	private List<BufferEntry> bufferSelectedEntries() {
 		try {
 			KeyStoreHistory history = kseFrame.getActiveKeyStoreHistory();
 			KeyStoreState currentState = history.getCurrentState();
 
-			String alias = kseFrame.getSelectedEntryAlias();
+			String[] aliases = kseFrame.getSelectedEntryAliases();
 
-			if (alias == null) {
+			if (aliases.length == 0) {
 				return null;
 			}
 
-			BufferEntry bufferEntry = null;
 
 			KeyStore keyStore = currentState.getKeyStore();
+			KeyStoreState newState = currentState.createBasisForNextState(this);
+			KeyStore newKeyStore = newState.getKeyStore();
+			List<BufferEntry> bufferEntries = new ArrayList<>();
+			for (String alias : aliases) {
+				BufferEntry bufferEntry = null;
+				if (KeyStoreUtil.isKeyEntry(alias, keyStore)) {
+					Password password = getEntryPassword(alias, currentState);
 
-			if (KeyStoreUtil.isKeyEntry(alias, keyStore)) {
-				Password password = getEntryPassword(alias, currentState);
+					if (password == null) {
+						continue;
+					}
 
-				if (password == null) {
-					return null;
+					Key key = keyStore.getKey(alias, password.toCharArray());
+
+					if (key instanceof PrivateKey) {
+						JOptionPane.showMessageDialog(frame,
+								res.getString("CutAction.NoCutKeyEntryWithPrivateKey.message"),
+								res.getString("CutAction.Cut.Title"), JOptionPane.WARNING_MESSAGE);
+
+						continue;
+					}
+
+					bufferEntry = new KeyBufferEntry(alias, true, key, password);
+				} else if (KeyStoreUtil.isTrustedCertificateEntry(alias, keyStore)) {
+					Certificate certificate = keyStore.getCertificate(alias);
+
+					bufferEntry = new TrustedCertificateBufferEntry(alias, true, certificate);
+				} else if (KeyStoreUtil.isKeyPairEntry(alias, keyStore)) {
+					Password password = getEntryPassword(alias, currentState);
+
+					if (password == null) {
+						continue;
+					}
+
+					PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, password.toCharArray());
+					Certificate[] certificateChain = keyStore.getCertificateChain(alias);
+
+					bufferEntry = new KeyPairBufferEntry(alias, true, privateKey, password, certificateChain);
 				}
-
-				Key key = keyStore.getKey(alias, password.toCharArray());
-
-				if (key instanceof PrivateKey) {
-					JOptionPane.showMessageDialog(frame,
-							res.getString("CutAction.NoCutKeyEntryWithPrivateKey.message"),
-							res.getString("CutAction.Cut.Title"), JOptionPane.WARNING_MESSAGE);
-
-					return null;
+				if (bufferEntry != null) {
+					bufferEntries.add(bufferEntry);
+					newKeyStore.deleteEntry(alias);
+					newState.removeEntryPassword(alias);
 				}
-
-				bufferEntry = new KeyBufferEntry(alias, true, key, password);
-			} else if (KeyStoreUtil.isTrustedCertificateEntry(alias, keyStore)) {
-				Certificate certificate = keyStore.getCertificate(alias);
-
-				bufferEntry = new TrustedCertificateBufferEntry(alias, true, certificate);
-			} else if (KeyStoreUtil.isKeyPairEntry(alias, keyStore)) {
-				Password password = getEntryPassword(alias, currentState);
-
-				if (password == null) {
-					return null;
-				}
-
-				PrivateKey privateKey = (PrivateKey) keyStore.getKey(alias, password.toCharArray());
-				Certificate[] certificateChain = keyStore.getCertificateChain(alias);
-
-				bufferEntry = new KeyPairBufferEntry(alias, true, privateKey, password, certificateChain);
 			}
 
-			KeyStoreState newState = currentState.createBasisForNextState(this);
 
-			keyStore = newState.getKeyStore();
 
-			keyStore.deleteEntry(alias);
-			newState.removeEntryPassword(alias);
 
 			currentState.append(newState);
 
-			return bufferEntry;
+			return bufferEntries;
 		} catch (Exception ex) {
 			DError.displayError(frame, ex);
 			return null;

--- a/kse/src/org/kse/gui/actions/DeleteMultipleEntriesAction.java
+++ b/kse/src/org/kse/gui/actions/DeleteMultipleEntriesAction.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2020 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.gui.actions;
+
+import org.kse.gui.KseFrame;
+import org.kse.gui.error.DError;
+import org.kse.utilities.history.HistoryAction;
+import org.kse.utilities.history.KeyStoreHistory;
+import org.kse.utilities.history.KeyStoreState;
+
+import javax.swing.*;
+import java.awt.*;
+import java.security.KeyStore;
+import java.text.MessageFormat;
+
+/**
+ * Action to delete multiple selected entries.
+ *
+ */
+public class DeleteMultipleEntriesAction extends KeyStoreExplorerAction implements HistoryAction {
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Construct action.
+	 *
+	 * @param kseFrame
+	 *            KeyStore Explorer frame
+	 */
+	public DeleteMultipleEntriesAction(KseFrame kseFrame) {
+		super(kseFrame);
+
+		putValue(LONG_DESCRIPTION, res.getString("DeleteMultipleEntriesAction.statusbar"));
+		putValue(NAME, res.getString("DeleteMultipleEntriesAction.text"));
+		putValue(SHORT_DESCRIPTION, res.getString("DeleteMultipleEntriesAction.tooltip"));
+		putValue(
+				SMALL_ICON,
+				new ImageIcon(Toolkit.getDefaultToolkit().createImage(
+						getClass().getResource("images/delete.png"))));
+	}
+
+	@Override
+	public String getHistoryDescription() {
+		return (String) getValue(NAME);
+	}
+
+	/**
+	 * Do action.
+	 */
+	@Override
+	protected void doAction() {
+		deleteSelectedEntries();
+	}
+
+	/**
+	 * Let the user delete the selected KeyStore entry.
+	 */
+	public void deleteSelectedEntries() {
+		String[] aliases = kseFrame.getSelectedEntryAliases();
+		if (aliases.length == 0) {
+			return;
+		}
+
+		try {
+			KeyStoreHistory history = kseFrame.getActiveKeyStoreHistory();
+
+			KeyStoreState currentState = history.getCurrentState();
+			KeyStoreState newState = currentState.createBasisForNextState(this);
+
+			KeyStore keyStore = newState.getKeyStore();
+
+			int selected = JOptionPane.showConfirmDialog(frame, res.getString("DeleteMultipleEntriesAction.ConfirmDelete.message"),
+					res.getString("DeleteMultipleEntriesAction.DeleteEntry.Title"), JOptionPane.YES_NO_OPTION);
+
+			if (selected != JOptionPane.YES_OPTION) {
+				return;
+			}
+
+			for (String alias : aliases) {
+				keyStore.deleteEntry(alias);
+				newState.removeEntryPassword(alias);
+			}
+
+			currentState.append(newState);
+
+			kseFrame.updateControls(true);
+		} catch (Exception ex) {
+			DError.displayError(frame, ex);
+		}
+	}
+}

--- a/kse/src/org/kse/gui/actions/resources.properties
+++ b/kse/src/org/kse/gui/actions/resources.properties
@@ -99,6 +99,12 @@ DeleteTrustedCertificateAction.statusbar             = Delete the Trusted Certif
 DeleteTrustedCertificateAction.text                  = Delete
 DeleteTrustedCertificateAction.tooltip               = Delete Trusted Certificate entry
 
+DeleteMultipleEntriesAction.ConfirmDelete.message = Are you sure that you want to delete the selected entries?
+DeleteMultipleEntriesAction.DeleteEntry.Title     = Delete selected entries
+DeleteMultipleEntriesAction.statusbar             = Delete selected entries
+DeleteMultipleEntriesAction.text                  = Delete
+DeleteMultipleEntriesAction.tooltip               = Delete selected entries
+
 DetectFileTypeAction.CryptographicFileType.Title = Cryptographic File Type
 DetectFileTypeAction.DetectFileType.Title        = Detect File Type
 DetectFileTypeAction.DetectFileType.button       = Detect Type

--- a/kse/src/org/kse/gui/actions/resources_de.properties
+++ b/kse/src/org/kse/gui/actions/resources_de.properties
@@ -100,6 +100,12 @@ DeleteTrustedCertificateAction.statusbar             = Eintrag f\u00FCr vertraue
 DeleteTrustedCertificateAction.text                  = L\u00F6schen
 DeleteTrustedCertificateAction.tooltip               = Eintrag f\u00FCr vertrauensw\u00FCrdiges Zertifikat l\u00F6schen
 
+DeleteMultipleEntriesAction.ConfirmDelete.message = Sind Sie sicher, dass sie die ausgew\u00E4hlten Eintr\u00E4ge l\u00F6schen wollen?
+DeleteMultipleEntriesAction.DeleteEntry.Title     = Ausgew\u00E4hlte Eintr\u00E4ge l\u00F6schen
+DeleteMultipleEntriesAction.statusbar             = Ausgew\u00E4hlte Eintr\u00E4ge l\u00F6schen
+DeleteMultipleEntriesAction.text                  = L\u00F6schen
+DeleteMultipleEntriesAction.tooltip               = Ausgew\u00E4hlte Eintr\u00E4ge l\u00F6schen
+
 DetectFileTypeAction.CryptographicFileType.Title = Kryptographischer Dateityp
 DetectFileTypeAction.DetectFileType.Title        = Dateityp ermitteln
 DetectFileTypeAction.DetectFileType.button       = Typ ermitteln

--- a/kse/src/org/kse/utilities/buffer/Buffer.java
+++ b/kse/src/org/kse/utilities/buffer/Buffer.java
@@ -19,12 +19,14 @@
  */
 package org.kse.utilities.buffer;
 
+import java.util.List;
+
 /**
  * Singleton buffer for copy/paste. Holds at most one KeyStore entry.
  *
  */
 public class Buffer {
-	private static BufferEntry bufferEntry;
+	private static List<BufferEntry> bufferEntries;
 
 	private Buffer() {
 	}
@@ -32,11 +34,11 @@ public class Buffer {
 	/**
 	 * Populate buffer with supplied entry.
 	 *
-	 * @param bufferEntry
+	 * @param bufferEntries
 	 *            Buffer entry
 	 */
-	public static void populate(BufferEntry bufferEntry) {
-		Buffer.bufferEntry = bufferEntry;
+	public static void populate(List<BufferEntry> bufferEntries) {
+		Buffer.bufferEntries = bufferEntries;
 	}
 
 	/**
@@ -44,8 +46,8 @@ public class Buffer {
 	 *
 	 * @return Buffer entry or null if empty
 	 */
-	public static BufferEntry interrogate() {
-		return bufferEntry;
+	public static List<BufferEntry> interrogate() {
+		return bufferEntries;
 	}
 
 	/**
@@ -70,10 +72,12 @@ public class Buffer {
 	 * Clear buffer.
 	 */
 	public static void clear() {
-		if (bufferEntry != null) {
-			bufferEntry.clear();
+		if (bufferEntries != null) {
+			for (BufferEntry bufferEntry : bufferEntries) {
+				bufferEntry.clear();
+			}
 		}
 
-		bufferEntry = null;
+		bufferEntries = null;
 	}
 }


### PR DESCRIPTION
This PR allows users to select more than one entry in the keystore table (by pressing SHIFT or CTRL).

The following operations are supported for multiple entries:
- copy
- cut
- paste
- delete