### PR TITLE
Allow running the application directly with './gradlew run' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Official website: http://keystore-explorer.org/
  
 ## Building
 
-To do a clean build, issue the following command:
+To do a clean build, issue the following command from the `kse` directory:
 
     $ ./gradlew clean build
 
@@ -46,6 +46,12 @@ For the Windows installer:
 For the MacOS application:    
 
     $ ./gradlew appbundler
+
+## Running
+
+To run the application, issue the following command from the `kse` directory:
+
+    $ ./gradlew run
 
 ## Contributing
 

--- a/kse/build.gradle
+++ b/kse/build.gradle
@@ -27,6 +27,7 @@ Notes:
 - Tasks 'signapp' and 'dmg' work only under macOS.
 */
 plugins {
+	id 'application'
 	id 'java'
 	id 'eclipse'
 	id 'idea'
@@ -89,6 +90,10 @@ ext {
 
 	// Main class (for manifest entry)
 	mainClassName = "org.kse.KSE"
+}
+
+application {
+	mainClass = project.mainClassName
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
This PRs simplifies running the application directly from a fresh clone without having to package the application using the gradle Application Plugin: https://docs.gradle.org/current/userguide/application_plugin.html

Without this change, the `./gradlew run` command would fail with the following error message:

```
# ./gradlew run
> Task :run FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':run'.
> No main class specified and classpath is not an executable jar.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.4/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 631ms
3 actionable tasks: 1 executed, 2 up-to-date
```