### PR TITLE
Use Bouncy Castle for PKCS12 keystores

### DIFF
--- a/kse/src/org/kse/crypto/keystore/KeyStoreUtil.java
+++ b/kse/src/org/kse/crypto/keystore/KeyStoreUtil.java
@@ -407,7 +407,7 @@ public final class KeyStoreUtil {
 
 	private static KeyStore getKeyStoreInstance(KeyStoreType keyStoreType) throws CryptoException {
 		try {
-			if (keyStoreType == BKS || keyStoreType == BKS_V1 || keyStoreType == UBER || keyStoreType == BCFKS) {
+			if (keyStoreType == BKS || keyStoreType == BKS_V1 || keyStoreType == UBER || keyStoreType == BCFKS || keyStoreType == PKCS12) {
 				if (Security.getProvider(BOUNCY_CASTLE.jce()) == null) {
 					throw new CryptoException(MessageFormat.format(res.getString("NoProvider.exception.message"),
 							BOUNCY_CASTLE.jce()));


### PR DESCRIPTION
Keystore Explorer currently fails to open PKCS12/PFX keystores that use AES. 
An example of how to create such keystore:

```
openssl pkcs12 -export -inkey key.key -in cert.crt -out test.p12 -certpbe AES-256-CBC -keypbe AES-256-CBC
```

This small PR makes it use the Bouncy Castle library which works with AES encryption and can open such keystores.