### PR TITLE
fix order open files clipboard

### DIFF
--- a/kse/src/org/kse/gui/actions/ExamineClipboardAction.java
+++ b/kse/src/org/kse/gui/actions/ExamineClipboardAction.java
@@ -110,10 +110,6 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
 		Transferable t = clipboard.getContents(null);
 		try {
 
-			if (t.isDataFlavorSupported(DataFlavor.stringFlavor)) {
-				show((String) t.getTransferData(DataFlavor.stringFlavor));
-			}
-
 			if (t.isDataFlavorSupported(DataFlavor.javaFileListFlavor)) {
 
 				@SuppressWarnings("unchecked")
@@ -122,6 +118,11 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
 				// open files in new thread, so we can return quickly
 				SwingUtilities.invokeLater(() -> DroppedFileHandler.openFiles(kseFrame, droppedFiles));
 			}
+			else
+			if (t.isDataFlavorSupported(DataFlavor.stringFlavor)) {
+				show((String) t.getTransferData(DataFlavor.stringFlavor));
+			}
+
 		} catch (UnsupportedFlavorException e) {
 			// ignore
 		} catch (IOException e) {


### PR DESCRIPTION
When I copy a list of files, I first get an error of not recognizing the file type and then open them.

it is now corrected.