### PR TITLE
Upd crl text statusbar, crl filename lowercase, default crl pem format

### DIFF
--- a/kse/src/org/kse/gui/actions/SignCrlAction.java
+++ b/kse/src/org/kse/gui/actions/SignCrlAction.java
@@ -116,7 +116,7 @@ public class SignCrlAction extends KeyStoreExplorerAction {
 
 				x509CRL = signCrl(crlNumber, effectiveDate, nextUpdate, certs[0], privateKey, signatureAlgorithm,
 						mapRevoked, provider);
-				String newFileName = X509CertUtil.getShortName(certs[0]);
+				String newFileName = X509CertUtil.getShortName(certs[0]).toLowerCase();
 				DExportCrl dExportCrl = new DExportCrl(frame, newFileName);
 				dExportCrl.setLocationRelativeTo(frame);
 				dExportCrl.setVisible(true);

--- a/kse/src/org/kse/gui/actions/resources.properties
+++ b/kse/src/org/kse/gui/actions/resources.properties
@@ -571,7 +571,7 @@ ShowHideToolBarAction.tooltip   = Tool Bar
 
 SignCrlAction.SignCrl.Title             = Sign CRL
 SignCrlAction.SignCrlSuccessful.message = Export CRL successful.
-SignCrlAction.statusbar                 = Sign CRL
+SignCrlAction.statusbar                 = Sign a Certificate Revocation List (CRL) using the Key Pair entry
 SignCrlAction.text                      = Sign CRL
 SignCrlAction.tooltip                   = Sign CRL
 

--- a/kse/src/org/kse/gui/dialogs/importexport/DExportCrl.java
+++ b/kse/src/org/kse/gui/dialogs/importexport/DExportCrl.java
@@ -100,7 +100,7 @@ public class DExportCrl extends JEscDialog {
 		gbc_jlExportPem.gridy = 4;
 
 		jcbExportPem = new JCheckBox();
-		jcbExportPem.setSelected(false);
+		jcbExportPem.setSelected(true);
 		jcbExportPem.setToolTipText(res.getString("DExportCrl.jcbExportPem.tooltip"));
 		GridBagConstraints gbc_jcbExportPem = (GridBagConstraints) gbcEdCtrl.clone();
 		gbc_jcbExportPem.gridy = 4;


### PR DESCRIPTION
https://www.postgresql.org/docs/14/ssl-tcp.html
ssl_crl_file

The documentation does not say it but when doing postgresql tests it does not allow crl in DER format since several crl can be added in the same file, in case they are using intermediate ca