### PR TITLE
Improve `FindAction.NotFound.message` with `MessageFormat.format` (for i18n)

### DIFF
--- a/kse/src/org/kse/gui/actions/FindAction.java
+++ b/kse/src/org/kse/gui/actions/FindAction.java
@@ -3,6 +3,7 @@ package org.kse.gui.actions;
 import java.awt.Toolkit;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
+import java.text.MessageFormat;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;

--- a/kse/src/org/kse/gui/actions/FindAction.java
+++ b/kse/src/org/kse/gui/actions/FindAction.java
@@ -53,7 +53,8 @@ public class FindAction extends KeyStoreExplorerAction {
 				Set<String> aliases = findEntryAlias(name); 
 				if (aliases.isEmpty()) {
 					JOptionPane.showMessageDialog(frame,
-							dialog.getEntryName() + " " + res.getString("FindAction.NotFound.message"),
+							MessageFormat.format(res.getString("FindAction.NotFound.message"),
+									dialog.getEntryName()),
 							res.getString("FindAction.Find.Title"), JOptionPane.WARNING_MESSAGE);
 				} else {
 					kseFrame.setSelectedEntriesByAliases(aliases);

--- a/kse/src/org/kse/gui/actions/FindAction.java
+++ b/kse/src/org/kse/gui/actions/FindAction.java
@@ -53,8 +53,7 @@ public class FindAction extends KeyStoreExplorerAction {
 				Set<String> aliases = findEntryAlias(name); 
 				if (aliases.isEmpty()) {
 					JOptionPane.showMessageDialog(frame,
-							MessageFormat.format(res.getString("FindAction.NotFound.message"),
-									dialog.getEntryName()),
+							MessageFormat.format(res.getString("FindAction.NotFound.message"), name),
 							res.getString("FindAction.Find.Title"), JOptionPane.WARNING_MESSAGE);
 				} else {
 					kseFrame.setSelectedEntriesByAliases(aliases);

--- a/kse/src/org/kse/gui/actions/resources.properties
+++ b/kse/src/org/kse/gui/actions/resources.properties
@@ -244,7 +244,7 @@ ExportTrustedCertificatePublicKeyAction.text                                    
 ExportTrustedCertificatePublicKeyAction.tooltip                                  = Export Trusted Certificate entry's public key
 
 FindAction.Find.Title       = Find
-FindAction.NotFound.message = ''{0}'' Not found
+FindAction.NotFound.message = ''{0}'' not found!
 FindAction.accelerator      = F
 FindAction.statusbar        = Find KeyStore entry
 FindAction.text             = Find

--- a/kse/src/org/kse/gui/actions/resources.properties
+++ b/kse/src/org/kse/gui/actions/resources.properties
@@ -244,7 +244,7 @@ ExportTrustedCertificatePublicKeyAction.text                                    
 ExportTrustedCertificatePublicKeyAction.tooltip                                  = Export Trusted Certificate entry's public key
 
 FindAction.Find.Title       = Find
-FindAction.NotFound.message = Not found
+FindAction.NotFound.message = ''{0}'' Not found
 FindAction.accelerator      = F
 FindAction.statusbar        = Find KeyStore entry
 FindAction.text             = Find

--- a/kse/src/org/kse/gui/actions/resources_de.properties
+++ b/kse/src/org/kse/gui/actions/resources_de.properties
@@ -246,7 +246,7 @@ ExportTrustedCertificatePublicKeyAction.text                                    
 ExportTrustedCertificatePublicKeyAction.tooltip                                  = \u00D6ffentlichen Schl\u00FCssel des vertrauensw\u00FCrdigen Zertifikates exportieren
 
 FindAction.Find.Title       = Finden
-FindAction.NotFound.message = \u00BB{0}\u00AB Nicht gefunden
+FindAction.NotFound.message = \u00BB{0}\u00AB nicht gefunden!
 FindAction.accelerator=F
 FindAction.statusbar        = KeyStore-Eintrag finden
 FindAction.text             = Suchen

--- a/kse/src/org/kse/gui/actions/resources_de.properties
+++ b/kse/src/org/kse/gui/actions/resources_de.properties
@@ -246,7 +246,7 @@ ExportTrustedCertificatePublicKeyAction.text                                    
 ExportTrustedCertificatePublicKeyAction.tooltip                                  = \u00D6ffentlichen Schl\u00FCssel des vertrauensw\u00FCrdigen Zertifikates exportieren
 
 FindAction.Find.Title       = Finden
-FindAction.NotFound.message = Nicht gefunden
+FindAction.NotFound.message = \u00BB{0}\u00AB Nicht gefunden
 FindAction.accelerator=F
 FindAction.statusbar        = KeyStore-Eintrag finden
 FindAction.text             = Suchen

--- a/kse/src/org/kse/gui/actions/resources_fr.properties
+++ b/kse/src/org/kse/gui/actions/resources_fr.properties
@@ -246,7 +246,7 @@ ExportTrustedCertificatePublicKeyAction.text                                    
 ExportTrustedCertificatePublicKeyAction.tooltip                                  = Exporter la clef publique du certificat
 
 FindAction.Find.Title       = Rechercher
-FindAction.NotFound.message = Non trouv\u00E9
+FindAction.NotFound.message = \u00AB\u00A0{0}\u00A0\u00BB n\u2019a pas \u00E9t\u00E9 trouv\u00E9 dans les noms d\u2019alias.
 FindAction.accelerator      = F
 FindAction.statusbar        = Rechercher dans les \u2019\u00E9l\u00E9ments du magasin de certificats
 FindAction.text             = Rechercher


### PR DESCRIPTION
Thanks for #284.

Here is a PR, in order to improve `FindAction.NotFound.message` with `MessageFormat.format`.
_Especially for i18n of resource files._

(FYI  @jgrateron)