### PR TITLE
upd: Improve (enlarge) HexUtil and ASN.1 dump

### DIFF
--- a/kse/src/org/kse/gui/dialogs/DViewAsn1Dump.java
+++ b/kse/src/org/kse/gui/dialogs/DViewAsn1Dump.java
@@ -232,7 +232,7 @@ public class DViewAsn1Dump extends JEscFrame {
 
         jspAsn1Dump = PlatformUtil.createScrollPane(jtaAsn1Dump, ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
                                                     ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
-        jspAsn1Dump.setPreferredSize(new Dimension(500, 300));
+        jspAsn1Dump.setPreferredSize(new Dimension(800, 400));
         jpAsn1Dump.add(jspAsn1Dump, BorderLayout.CENTER);
 
         getContentPane().add(jpAsn1Dump, BorderLayout.CENTER);

--- a/kse/src/org/kse/utilities/io/HexUtil.java
+++ b/kse/src/org/kse/utilities/io/HexUtil.java
@@ -159,10 +159,10 @@ public class HexUtil {
      */
     public static String getHexClearDump(byte[] bytes) throws IOException {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes)) {
-            // Divide dump into 8 byte lines
+            // Divide dump into 16 bytes lines
             StringBuilder sb = new StringBuilder();
 
-            byte[] line = new byte[8];
+            byte[] line = new byte[16];
             int read = -1;
             boolean firstLine = true;
 
@@ -202,6 +202,10 @@ public class HexUtil {
             if ((cnt + 1) < len) {
                 // Divider between hex characters
                 sbHex.append(' ');
+                if (((cnt + 1) % 8) == 0) {
+                    // Divider between 8 hex characters
+                    sbHex.append(' ');
+                }
             }
 
             // Get clear character

--- a/kse/src/org/kse/utilities/io/HexUtil.java
+++ b/kse/src/org/kse/utilities/io/HexUtil.java
@@ -234,6 +234,10 @@ public class HexUtil {
         int i = bytes.length - len;
         for (int cnt = 0; cnt < i; cnt++) {
             strBuff.append("   "); // Each missing byte takes up three spaces
+            if (((cnt + 1) % 8) == 0) {
+                // Add a space for each 8 hex characters
+                strBuff.append(' ');
+            }
         }
 
         strBuff.append("   "); // The gap between hex and clear output is three


### PR DESCRIPTION
- [x] `getHexClearDump` on 16 bytes instead 8 bytes
- [x] Add one more space at 8 bytes on `getHexClearLineDump`
- [x] Improve size of `DViewAsn1Dump` dialog window

Ref.:
- From a @jgrateron's idea on https://github.com/kaikramer/keystore-explorer/issues/360#issuecomment-1454838468
- https://github.com/kaikramer/keystore-explorer/issues/360#issuecomment-1461084929
