### PR TITLE
Add configurable number of random bytes to serial number (#429)

### DIFF
--- a/kse/src/org/kse/gui/actions/PreferencesAction.java
+++ b/kse/src/org/kse/gui/actions/PreferencesAction.java
@@ -86,7 +86,8 @@ public class PreferencesAction extends ExitAction {
                                                      applicationSettings.getAutoUpdateCheckInterval(),
                                                      applicationSettings.getKeyStoreTableColumns(),
                                                      applicationSettings.isShowHiddenFilesEnabled(),
-                                                     applicationSettings.getPkcs12EncryptionSetting());
+                                                     applicationSettings.getPkcs12EncryptionSetting(),
+                                                     applicationSettings.getSnRandomBytes());
         dPreferences.setLocationRelativeTo(frame);
         dPreferences.setVisible(true);
 
@@ -114,6 +115,7 @@ public class PreferencesAction extends ExitAction {
         applicationSettings.setAutoUpdateCheckInterval(dPreferences.getAutoUpdateChecksInterval());
         applicationSettings.setShowHiddenFilesEnabled(dPreferences.isShowHiddenFilesEnabled());
         applicationSettings.setPkcs12EncryptionSetting(dPreferences.getPkcs12EncryptionSetting());
+        applicationSettings.setSnRandomBytes(dPreferences.getSnRandomBytes());
 
         Pkcs12Util.setEncryptionStrength(applicationSettings.getPkcs12EncryptionSetting());
 

--- a/kse/src/org/kse/gui/dialogs/DGenerateKeyPairCert.java
+++ b/kse/src/org/kse/gui/dialogs/DGenerateKeyPairCert.java
@@ -72,7 +72,9 @@ import org.kse.gui.datetime.JDateTime;
 import org.kse.gui.dialogs.extensions.DAddExtensions;
 import org.kse.gui.dialogs.sign.DListCertificatesKS;
 import org.kse.gui.error.DError;
+import org.kse.gui.preferences.ApplicationSettings;
 import org.kse.utilities.DialogViewer;
+import org.kse.utilities.SerialNumbers;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -194,7 +196,8 @@ public class DGenerateKeyPairCert extends JEscDialog {
 
         jlSerialNumber = new JLabel(res.getString("DGenerateKeyPairCert.jlSerialNumber.text"));
 
-        jtfSerialNumber = new JTextField("" + generateSerialNumber(), 20);
+        final int snRandomBytes = ApplicationSettings.getInstance().getSnRandomBytes();
+        jtfSerialNumber = new JTextField(SerialNumbers.fromCurrentTime(snRandomBytes), 20);
         jtfSerialNumber.setToolTipText(res.getString("DGenerateKeyPairCert.jtfSerialNumber.tooltip"));
 
         jlName = new JLabel(res.getString("DGenerateKeyPairCert.jlName.text"));
@@ -455,10 +458,6 @@ public class DGenerateKeyPairCert extends JEscDialog {
 
     private boolean hasCriticalSAN() {
         return extensions.isCritical(X509ExtensionType.SUBJECT_ALTERNATIVE_NAME.oid());
-    }
-
-    private long generateSerialNumber() {
-        return System.currentTimeMillis() / 1000;
     }
 
     /**

--- a/kse/src/org/kse/gui/dialogs/sign/DSignCsr.java
+++ b/kse/src/org/kse/gui/dialogs/sign/DSignCsr.java
@@ -93,7 +93,9 @@ import org.kse.gui.dialogs.DialogHelper;
 import org.kse.gui.dialogs.extensions.DAddExtensions;
 import org.kse.gui.dialogs.extensions.DViewExtensions;
 import org.kse.gui.error.DError;
+import org.kse.gui.preferences.ApplicationSettings;
 import org.kse.utilities.DialogViewer;
+import org.kse.utilities.SerialNumbers;
 import org.kse.utilities.asn1.Asn1Exception;
 
 import net.miginfocom.swing.MigLayout;
@@ -294,7 +296,8 @@ public class DSignCsr extends JEscDialog {
 
         jlSerialNumber = new JLabel(res.getString("DSignCsr.jlSerialNumber.text"));
 
-        jtfSerialNumber = new JTextField("" + generateSerialNumber(), 15);
+        final int snRandomBytes = ApplicationSettings.getInstance().getSnRandomBytes();
+        jtfSerialNumber = new JTextField(SerialNumbers.fromCurrentTime(snRandomBytes), 15);
         jtfSerialNumber.setToolTipText(res.getString("DSignCsr.jtfSerialNumber.tooltip"));
 
         jbTransferExtensions = new JButton(res.getString("DSignCsr.jbTransferExtensions.text"));
@@ -537,10 +540,6 @@ public class DSignCsr extends JEscDialog {
         }
 
         jtfCsrPublicKey.setCaretPosition(0);
-    }
-
-    private long generateSerialNumber() {
-        return System.currentTimeMillis() / 1000;
     }
 
     private void extensionsPressed() {

--- a/kse/src/org/kse/gui/preferences/ApplicationSettings.java
+++ b/kse/src/org/kse/gui/preferences/ApplicationSettings.java
@@ -115,6 +115,7 @@ public class ApplicationSettings {
     private static final String KSE3_COLUMNS = "kse3.columns";
     private static final String KSE3_SHOW_HIDDEN_FILES = "kse3.showhiddenfiles";
     private static final String KSE3_PKCS12_ENCRYPTION = "kse3.pkcs12encryption";
+    private static final String KSE3_SN_RANDOM_BYTES = "kse3.snrandombytes";
 
     private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -156,6 +157,7 @@ public class ApplicationSettings {
     private int expiryWarnDays;
     private boolean showHiddenFilesEnabled;
     private Pkcs12EncryptionSetting pkcs12EncryptionSetting;
+    private int snRandomBytes;
 
     private ApplicationSettings() {
 
@@ -383,6 +385,9 @@ public class ApplicationSettings {
 
         // pkcs12 encryption strong or compatible?
         pkcs12EncryptionSetting = Pkcs12EncryptionSetting.valueOf(preferences.get(KSE3_PKCS12_ENCRYPTION, "strong"));
+
+        // number of random bytes in serial number generation
+        snRandomBytes = preferences.getInt(KSE3_SN_RANDOM_BYTES, 0);
     }
 
     private File cleanFilePath(File filePath) {
@@ -498,6 +503,9 @@ public class ApplicationSettings {
 
         // pkcs12 encryption strong or compatible?
         preferences.put(KSE3_PKCS12_ENCRYPTION, pkcs12EncryptionSetting.name());
+
+        // number of random bytes in serial number generation
+        preferences.putInt(KSE3_SN_RANDOM_BYTES, snRandomBytes);
     }
 
     private void clearExistingRecentFiles(Preferences preferences) {
@@ -894,5 +902,13 @@ public class ApplicationSettings {
 
     public void setPkcs12EncryptionSetting(Pkcs12EncryptionSetting pkcs12EncryptionSetting) {
         this.pkcs12EncryptionSetting = pkcs12EncryptionSetting;
+    }
+
+    public int getSnRandomBytes() {
+        return snRandomBytes;
+    }
+
+    public void setSnRandomBytes(int snRandomBytes) {
+        this.snRandomBytes = snRandomBytes;
     }
 }

--- a/kse/src/org/kse/gui/preferences/DPreferences.java
+++ b/kse/src/org/kse/gui/preferences/DPreferences.java
@@ -120,6 +120,8 @@ public class DPreferences extends JEscDialog {
     private JCheckBox jcbLookFeelDecorated;
     private JLabel jlPkcs12Encryption;
     private JComboBox<Pkcs12EncryptionSetting> jcbPkcs12Encryption;
+    private JLabel jlSnRandomBytes;
+    private JSpinner jspSnRandomBytes;
     private JPanel jpInternetProxy;
     private JRadioButton jrbNoProxy;
     private JRadioButton jrbSystemProxySettings;
@@ -164,6 +166,7 @@ public class DPreferences extends JEscDialog {
     private String language;
     private boolean showHiddenFilesEnabled;
     private Pkcs12EncryptionSetting pkcs12EncryptionSetting;
+    private int snRandomBytes;
 
     private boolean autoUpdateChecksEnabled;
     private int autoUpdateChecksInterval;
@@ -238,13 +241,14 @@ public class DPreferences extends JEscDialog {
      * @param kstColumns                        Shown columns in the main table
      * @param showHiddenFilesEnabled            Show hidden files in file chooser
      * @param pkcs12EncryptionSetting           Strong or compatible PKCS#12 encryption?
+     * @param snRandomBytes                     Length of serial number random bytes
      */
     public DPreferences(JFrame parent, boolean useCaCertificates, File caCertificatesFile,
                         boolean useWinTrustedRootCertificates, boolean enableImportTrustedCertTrustCheck,
                         boolean enableImportCaReplyTrustCheck, PasswordQualityConfig passwordQualityConfig,
                         String defaultDN, String language, boolean autoUpdateChecksEnabled,
                         int autoUpdateChecksInterval, KeyStoreTableColumns kstColumns, boolean showHiddenFilesEnabled,
-                        Pkcs12EncryptionSetting pkcs12EncryptionSetting) {
+                        Pkcs12EncryptionSetting pkcs12EncryptionSetting, int snRandomBytes) {
         super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
         setResizable(true);
         Dimension d = new Dimension(900, 500);
@@ -263,6 +267,7 @@ public class DPreferences extends JEscDialog {
         this.expiryWarnDays = kstColumns.getExpiryWarnDays();
         this.showHiddenFilesEnabled = showHiddenFilesEnabled;
         this.pkcs12EncryptionSetting = pkcs12EncryptionSetting;
+        this.snRandomBytes = snRandomBytes;
         initComponents();
     }
 
@@ -535,6 +540,10 @@ public class DPreferences extends JEscDialog {
         jcbPkcs12Encryption.setSelectedItem(pkcs12EncryptionSetting);
         jcbPkcs12Encryption.setToolTipText(res.getString("DPreferences.jcbPkcs12Encryption.tooltip"));
 
+        jlSnRandomBytes = new JLabel(res.getString("DPreferences.jlSnRandomBytes.text"));
+        SpinnerNumberModel snSpinnerModel = new SpinnerNumberModel(snRandomBytes, 0.0, 16.0, 1.0);
+        jspSnRandomBytes = new JSpinner(snSpinnerModel);
+
         // layout
         jpUI = new JPanel();
         rightJPanel.add(jpUI, "jpCard2");
@@ -557,7 +566,9 @@ public class DPreferences extends JEscDialog {
         jpUI.add(jlFileChooser, "");
         jpUI.add(jcbShowHiddenFiles, "spanx, wrap unrel");
         jpUI.add(jlPkcs12Encryption, "");
-        jpUI.add(jcbPkcs12Encryption, "");
+        jpUI.add(jcbPkcs12Encryption, "spanx, wrap unrel");
+        jpUI.add(jlSnRandomBytes, "");
+        jpUI.add(jspSnRandomBytes, "");
 
         jcbEnableAutoUpdateChecks
                 .addItemListener(evt -> jspAutoUpdateCheckInterval.setEnabled(jcbEnableAutoUpdateChecks.isSelected()));
@@ -892,6 +903,8 @@ public class DPreferences extends JEscDialog {
 
         pkcs12EncryptionSetting = (Pkcs12EncryptionSetting) jcbPkcs12Encryption.getSelectedItem();
 
+        snRandomBytes = ((Number) jspSnRandomBytes.getValue()).intValue();
+
         // These may fail:
         boolean returnValue = storeDefaultDN();
         // bitwise and assignment
@@ -1208,6 +1221,15 @@ public class DPreferences extends JEscDialog {
     }
 
     /**
+     * Returns length of serial number random bytes
+     * 
+     * @return serial number random bytes
+     */
+    public int getSnRandomBytes() {
+        return snRandomBytes;
+    }
+
+    /**
      * Check if columns have changed
      *
      * @return True if changed
@@ -1322,7 +1344,7 @@ public class DPreferences extends JEscDialog {
     public static void main(String[] args) throws Exception {
         DPreferences dialog = new DPreferences(new javax.swing.JFrame(), true, new File(""), true, true, true,
                                                new PasswordQualityConfig(true, true, 100), "", "en", true, 14,
-                                               new KeyStoreTableColumns(), true, Pkcs12EncryptionSetting.strong);
+                                               new KeyStoreTableColumns(), true, Pkcs12EncryptionSetting.strong, 0);
         DialogViewer.run(dialog);
     }
 }

--- a/kse/src/org/kse/gui/preferences/resources.properties
+++ b/kse/src/org/kse/gui/preferences/resources.properties
@@ -92,6 +92,7 @@ DPreferences.jlLookFeelNote.text                           = Changing these sett
 DPreferences.jlMinimumPasswordQuality.text                 = Minimum Password Quality:
 DPreferences.jlPacUrl.text                                 = PAC URL:
 DPreferences.jlPkcs12Encryption.text                       = PKCS#12 Encryption:
+DPreferences.jlSnRandomBytes.text                          = S/N random bytes:
 DPreferences.jlSocksHost.text                              = SOCKS Proxy Host:
 DPreferences.jlSocksPort.text                              = Port:
 DPreferences.jlTrustChecks.text                            = Chain of trust checks are enabled for the following features:

--- a/kse/src/org/kse/gui/preferences/resources_de.properties
+++ b/kse/src/org/kse/gui/preferences/resources_de.properties
@@ -82,6 +82,7 @@ DPreferences.jlAutoUpdateChecks.text                       = Automatischer Updat
 DPreferences.jlAutoUpdateChecksDays.text                   = Tag(e)
 DPreferences.jlCaCertificatesFile.text                     = Schl\u00FCsselspeicher f\u00FCr CA-Zertifikate:
 DPreferences.jlExpiryWarning.text                          = Warnzeit (in Tagen) vor Zertifikatsablauf
+DPreferences.jlSnRandomBytes.text                          = Zuf\u00e4lligen Bytes der S/N:
 DPreferences.jlFileChooser.text                            = Dateiauswahldialog:
 DPreferences.jlHttpHost.text                               = HTTP-Proxy Server:
 DPreferences.jlHttpPort.text                               = Port:

--- a/kse/src/org/kse/gui/preferences/resources_fr.properties
+++ b/kse/src/org/kse/gui/preferences/resources_fr.properties
@@ -81,6 +81,7 @@ DPreferences.jlAutoUpdateChecks.text                       = V\u00E9rification a
 DPreferences.jlAutoUpdateChecksDays.text                   = jour(s)
 DPreferences.jlCaCertificatesFile.text                     = Magasin de certificats des AC\u00A0:
 DPreferences.jlExpiryWarning.text                          = D\u00E9lai d\u2019avertissement (en jours) avant l\u2019expiration du certificat
+DPreferences.jlSnRandomBytes.text                          = Octets al\u00e9atoires du S/N:
 DPreferences.jlFileChooser.text                            = S\u00E9lection de fichiers\u00A0:
 DPreferences.jlHttpHost.text                               = Serveur mandataire HTTP\u00A0:
 DPreferences.jlHttpPort.text                               = Port\u00A0:

--- a/kse/src/org/kse/utilities/SerialNumbers.java
+++ b/kse/src/org/kse/utilities/SerialNumbers.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2023 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.utilities;
+
+import java.math.BigInteger;
+import java.security.SecureRandom;
+
+public class SerialNumbers {
+    /**
+     * Returns a new serial number from current time and random bytes.
+     *
+     * @param randomBytes the length of random bytes
+     * @return new serial number
+     */
+    public static String fromCurrentTime(int randomBytes) {
+    	final long time = System.currentTimeMillis() / 1000;
+        if (randomBytes <= 0) {
+            return String.valueOf(time);
+        }
+        final SecureRandom rng = new SecureRandom();
+        // ensure most significant byte is positive
+        byte mostSigByte;
+        do {
+            mostSigByte = (byte) rng.nextInt();
+        } while (mostSigByte <= 0);
+        // generate remaining random bytes
+        final byte[] otherRandomBytes = new byte[randomBytes - 1];
+        rng.nextBytes(otherRandomBytes);
+        // magnitude of a big integer from random bytes and current time
+        final byte[] magnitude = new byte[randomBytes + 4];
+        magnitude[0] = mostSigByte;
+        System.arraycopy(otherRandomBytes, 0, magnitude, 1, otherRandomBytes.length);
+        magnitude[randomBytes] = (byte) (time >> 24);
+        magnitude[randomBytes + 1] = (byte) (time >> 16);
+        magnitude[randomBytes + 2] = (byte) (time >> 8);
+        magnitude[randomBytes + 3] = (byte) time;
+        // convert bytes to a string using big integer
+        return new BigInteger(1, magnitude).toString();
+    }
+
+    private SerialNumbers() {
+    }
+}


### PR DESCRIPTION
I made the number of random bytes added to s/n configurable. The default value of 0 produces the same s/n of current versions, i.e. unix timestamp in seconds.