### PR TITLE
Provide private key format to DViewPrivateKey dialog

### DIFF
--- a/kse/src/main/java/org/kse/crypto/privatekey/PrivateKeyFormat.java
+++ b/kse/src/main/java/org/kse/crypto/privatekey/PrivateKeyFormat.java
@@ -1,0 +1,15 @@
+package org.kse.crypto.privatekey;
+
+public enum PrivateKeyFormat {
+   PKCS1("PKCS#1"), PKCS8("PKCS#8"), MSPVK("MS PVK");
+
+   private String value;
+
+   private PrivateKeyFormat(String value) {
+      this.value = value;
+   }
+
+   public String getValue() {
+      return value;
+   }
+}

--- a/kse/src/main/java/org/kse/gui/actions/ExamineClipboardAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ExamineClipboardAction.java
@@ -36,6 +36,7 @@ import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 import javax.swing.ImageIcon;
@@ -54,6 +55,7 @@ import org.kse.crypto.filetype.CryptoFileUtil;
 import org.kse.crypto.privatekey.MsPvkUtil;
 import org.kse.crypto.privatekey.OpenSslPvkUtil;
 import org.kse.crypto.privatekey.Pkcs8Util;
+import org.kse.crypto.privatekey.PrivateKeyFormat;
 import org.kse.crypto.publickey.OpenSslPubUtil;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
@@ -262,6 +264,7 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
     private void showPrivateKey(byte[] data, CryptoFileType fileType) throws IOException, CryptoException {
         PrivateKey privKey = null;
         Password password = null;
+        PrivateKeyFormat format = null;
 
         switch (fileType) {
         case ENC_PKCS8_PVK:
@@ -270,9 +273,11 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = Pkcs8Util.loadEncrypted(data, password);
+            format = PrivateKeyFormat.PKCS8;
             break;
         case UNENC_PKCS8_PVK:
             privKey = Pkcs8Util.load(data);
+            format = PrivateKeyFormat.PKCS8;
             break;
         case ENC_OPENSSL_PVK:
             password = getPassword();
@@ -280,9 +285,11 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = OpenSslPvkUtil.loadEncrypted(data, password);
+            format = PrivateKeyFormat.PKCS1;
             break;
         case UNENC_OPENSSL_PVK:
             privKey = OpenSslPvkUtil.load(data);
+            format = PrivateKeyFormat.PKCS1;
             break;
         case ENC_MS_PVK:
             password = getPassword();
@@ -290,16 +297,18 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = MsPvkUtil.loadEncrypted(data, password);
+            format = PrivateKeyFormat.MSPVK;
             break;
         case UNENC_MS_PVK:
             privKey = MsPvkUtil.load(data);
+            format = PrivateKeyFormat.MSPVK;
             break;
         default:
             break;
         }
 
         DViewPrivateKey dViewPrivateKey = new DViewPrivateKey(frame, res.getString(
-                "ExamineClipboardAction.PrivateKeyDetails.Title"), "", privKey, applicationSettings);
+                "ExamineClipboardAction.PrivateKeyDetails.Title"), "", privKey, applicationSettings, Optional.ofNullable(format));
         dViewPrivateKey.setLocationRelativeTo(frame);
         dViewPrivateKey.setVisible(true);
     }

--- a/kse/src/main/java/org/kse/gui/actions/ExamineFileAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ExamineFileAction.java
@@ -30,6 +30,7 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 import java.util.Base64;
+import java.util.Optional;
 
 import javax.swing.ImageIcon;
 import javax.swing.JFileChooser;
@@ -47,6 +48,7 @@ import org.kse.crypto.filetype.CryptoFileUtil;
 import org.kse.crypto.privatekey.MsPvkUtil;
 import org.kse.crypto.privatekey.OpenSslPvkUtil;
 import org.kse.crypto.privatekey.Pkcs8Util;
+import org.kse.crypto.privatekey.PrivateKeyFormat;
 import org.kse.crypto.publickey.OpenSslPubUtil;
 import org.kse.crypto.signing.JarParser;
 import org.kse.crypto.x509.X509CertUtil;
@@ -250,10 +252,10 @@ public class ExamineFileAction extends KeyStoreExplorerAction {
     }
 
     private void openPrivateKey(File file, CryptoFileType fileType) throws IOException, CryptoException {
-
         byte[] data = decodeIfBase64(FileUtils.readFileToByteArray(file));
         PrivateKey privKey = null;
         Password password = null;
+        PrivateKeyFormat format = null;
 
         switch (fileType) {
         case ENC_PKCS8_PVK:
@@ -262,9 +264,11 @@ public class ExamineFileAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = Pkcs8Util.loadEncrypted(data, password);
+            format = PrivateKeyFormat.PKCS8;
             break;
         case UNENC_PKCS8_PVK:
             privKey = Pkcs8Util.load(data);
+            format = PrivateKeyFormat.PKCS8;
             break;
         case ENC_OPENSSL_PVK:
             password = getPassword(file);
@@ -272,9 +276,11 @@ public class ExamineFileAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = OpenSslPvkUtil.loadEncrypted(data, password);
+            format = PrivateKeyFormat.PKCS1;
             break;
         case UNENC_OPENSSL_PVK:
             privKey = OpenSslPvkUtil.load(data);
+            format = PrivateKeyFormat.PKCS1;
             break;
         case ENC_MS_PVK:
             password = getPassword(file);
@@ -282,16 +288,18 @@ public class ExamineFileAction extends KeyStoreExplorerAction {
                 return;
             }
             privKey = MsPvkUtil.loadEncrypted(data, password);
+            format = PrivateKeyFormat.MSPVK;
             break;
         case UNENC_MS_PVK:
             privKey = MsPvkUtil.load(data);
+            format = PrivateKeyFormat.MSPVK;
             break;
         default:
             break;
         }
 
         DViewPrivateKey dViewPrivateKey = new DViewPrivateKey(frame, MessageFormat.format(
-                res.getString("ExamineFileAction.PrivateKeyDetailsFile.Title"), file.getName()), FileNameUtil.removeExtension(file.getName()), privKey, applicationSettings);
+                res.getString("ExamineFileAction.PrivateKeyDetailsFile.Title"), file.getName()), FileNameUtil.removeExtension(file.getName()), privKey, applicationSettings, Optional.ofNullable(format));
         dViewPrivateKey.setLocationRelativeTo(frame);
         dViewPrivateKey.setVisible(true);
     }

--- a/kse/src/main/java/org/kse/gui/actions/KeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyDetailsAction.java
@@ -26,6 +26,7 @@ import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 import javax.crypto.SecretKey;
 import javax.swing.ImageIcon;
@@ -103,7 +104,7 @@ public class KeyDetailsAction extends KeyStoreExplorerAction {
                 PrivateKey privateKey = (PrivateKey) key;
 
                 DViewPrivateKey dViewPrivateKey = new DViewPrivateKey(frame, MessageFormat.format(
-                        res.getString("KeyDetailsAction.PrivateKeyDetailsEntry.Title"), alias), alias, privateKey, applicationSettings);
+                        res.getString("KeyDetailsAction.PrivateKeyDetailsEntry.Title"), alias), alias, privateKey, applicationSettings, Optional.empty());
                 dViewPrivateKey.setLocationRelativeTo(frame);
                 dViewPrivateKey.setVisible(true);
             } else if (key instanceof PublicKey) {

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
@@ -23,6 +23,7 @@ import java.awt.Toolkit;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 import javax.swing.ImageIcon;
 
@@ -76,7 +77,7 @@ public class KeyPairPrivateKeyDetailsAction extends KeyStoreExplorerAction {
             PrivateKey privKey = (PrivateKey) keyStore.getKey(alias, password.toCharArray());
 
             DViewPrivateKey dViewPrivateKey = new DViewPrivateKey(frame, MessageFormat.format(
-                    res.getString("KeyPairPrivateKeyDetailsAction.PrivKeyDetailsEntry.Title"), alias), alias, privKey, applicationSettings);
+                    res.getString("KeyPairPrivateKeyDetailsAction.PrivKeyDetailsEntry.Title"), alias), alias, privKey, applicationSettings, Optional.empty());
             dViewPrivateKey.setLocationRelativeTo(frame);
             dViewPrivateKey.setVisible(true);
         } catch (Exception ex) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
@@ -33,6 +33,7 @@ import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.MessageFormat;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 import javax.swing.JButton;
@@ -52,6 +53,7 @@ import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.keypair.KeyPairUtil;
+import org.kse.crypto.privatekey.PrivateKeyFormat;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.JEscDialog;
 import org.kse.gui.LnfUtil;
@@ -95,6 +97,8 @@ public class DViewPrivateKey extends JEscDialog {
 
     private ApplicationSettings applicationSettings;
 
+    private Optional<PrivateKeyFormat> format;
+
     /**
      * Creates a new DViewPrivateKey dialog.
      *
@@ -103,11 +107,12 @@ public class DViewPrivateKey extends JEscDialog {
      * @param privateKey Private key to display
      * @throws CryptoException A problem was encountered getting the private key's details
      */
-    public DViewPrivateKey(JFrame parent, String title, String alias, PrivateKey privateKey, ApplicationSettings applicationSettings) throws CryptoException {
+    public DViewPrivateKey(JFrame parent, String title, String alias, PrivateKey privateKey, ApplicationSettings applicationSettings, Optional<PrivateKeyFormat> format) throws CryptoException {
         super(parent, title, Dialog.ModalityType.DOCUMENT_MODAL);
         this.alias = alias;
         this.privateKey = privateKey;
         this.applicationSettings = applicationSettings;
+        this.format = format;
         initComponents();
     }
 
@@ -122,6 +127,7 @@ public class DViewPrivateKey extends JEscDialog {
     public DViewPrivateKey(JDialog parent, String title, PrivateKey privateKey) throws CryptoException {
         super(parent, title, ModalityType.DOCUMENT_MODAL);
         this.privateKey = privateKey;
+        this.format = Optional.empty();
         initComponents();
         jbExport.setVisible(false);
     }
@@ -291,7 +297,7 @@ public class DViewPrivateKey extends JEscDialog {
             jtfKeySize.setText(MessageFormat.format(res.getString("DViewPrivateKey.jtfKeySize.text"), "?"));
         }
 
-        jtfFormat.setText(privateKey.getFormat());
+        jtfFormat.setText(format.map(PrivateKeyFormat::getValue).orElse(privateKey.getFormat()));
 
         jtaEncoded.setText(new BigInteger(1, privateKey.getEncoded()).toString(16).toUpperCase());
         jtaEncoded.setCaretPosition(0);
@@ -342,7 +348,7 @@ public class DViewPrivateKey extends JEscDialog {
         KeyPair keyPair = keyGen.genKeyPair();
 
         PrivateKey privKey = keyPair.getPrivate();
-        DViewPrivateKey dialog = new DViewPrivateKey(new javax.swing.JFrame(), "Title", "private", privKey, null);
+        DViewPrivateKey dialog = new DViewPrivateKey(new javax.swing.JFrame(), "Title", "private", privKey, null, Optional.empty());
         DialogViewer.run(dialog);
     }
 }


### PR DESCRIPTION
fixes #436 

I simply passed a new argument to DViewPrivateKey to provide the original format the file/clipboard was, if present the current value (`privateKey.getFormat()`) is used

I'm not familiar with MS keys so I can change the naming.
