### PR TITLE
Add serial number formatting (#406)

### DIFF
--- a/kse/src/org/kse/ApplicationSettings.java
+++ b/kse/src/org/kse/ApplicationSettings.java
@@ -40,6 +40,7 @@ import javax.swing.JTabbedPane;
 import org.kse.crypto.digest.DigestType;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.secretkey.SecretKeyType;
+import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KeyStoreTableColumns;
 import org.kse.gui.KseFrame;
 import org.kse.gui.password.PasswordQualityConfig;
@@ -108,6 +109,7 @@ public class ApplicationSettings {
 	private static final String KSE3_EXPIRY_WARN_DAYS = "kse3.expirywarndays";
 	private static final String KSE3_COLUMNS = "kse3.columns";
 	private static final String KSE3_SHOW_HIDDEN_FILES = "kse3.showhiddenfiles";
+	private static final String KSE3_SERIAL_FORMATTING = "kse3.serialformatting";
 
 
 	private DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
@@ -146,6 +148,7 @@ public class ApplicationSettings {
 	private KeyStoreTableColumns kstColumns = new KeyStoreTableColumns();
 	private int expiryWarnDays;
 	private boolean showHiddenFilesEnabled;
+	private X509CertUtil.SerialNumberFormatter serialNumberFormatter;
 
 	private ApplicationSettings() {
 
@@ -361,6 +364,14 @@ public class ApplicationSettings {
 
 		// show hidden files in file chooser dialogs?
 		showHiddenFilesEnabled = preferences.getBoolean(KSE3_SHOW_HIDDEN_FILES, true);
+
+		// serial number formatting
+		try {
+			serialNumberFormatter = X509CertUtil.SerialNumberFormatter.valueOf(
+					preferences.get(KSE3_SERIAL_FORMATTING, X509CertUtil.SerialNumberFormatter.HEX_STRING.name()));
+		} catch (IllegalArgumentException e) {
+			serialNumberFormatter = X509CertUtil.SerialNumberFormatter.HEX_STRING;
+		}
 	}
 
 	private File cleanFilePath(File filePath) {
@@ -470,6 +481,9 @@ public class ApplicationSettings {
 
 		// hide/show hidden files in file chooser
 		preferences.putBoolean(KSE3_SHOW_HIDDEN_FILES, isShowHiddenFilesEnabled());
+
+		// serial number formatter
+		preferences.put(KSE3_SERIAL_FORMATTING, getSerialNumberFormatter().name());
 	}
 
 	private void clearExistingRecentFiles(Preferences preferences) {
@@ -838,5 +852,13 @@ public class ApplicationSettings {
 
 	public void setShowHiddenFilesEnabled(boolean showHiddenFilesEnabled) {
 		this.showHiddenFilesEnabled = showHiddenFilesEnabled;
+	}
+
+	public X509CertUtil.SerialNumberFormatter getSerialNumberFormatter() {
+		return serialNumberFormatter;
+	}
+
+	public void setSerialNumberFormatter(X509CertUtil.SerialNumberFormatter serialNumberFormatter) {
+		this.serialNumberFormatter = serialNumberFormatter;
 	}
 }

--- a/kse/src/org/kse/crypto/x509/X509CertUtil.java
+++ b/kse/src/org/kse/crypto/x509/X509CertUtil.java
@@ -50,6 +50,7 @@ import javax.security.auth.x500.X500Principal;
 
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.util.encoders.Base64;
+import org.kse.ApplicationSettings;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.signing.SignatureType;
 import org.kse.utilities.ArrayUtils;
@@ -752,4 +753,39 @@ public final class X509CertUtil {
 		return new BigInteger(1, cert.getSerialNumber().toByteArray()).toString(10);
 	}
 
+	public static String getFormattedSerialNumber(X509Certificate cert) {
+		String rawHexString = new BigInteger(1, cert.getSerialNumber().toByteArray()).toString(16).toUpperCase();
+		return ApplicationSettings.getInstance().getSerialNumberFormatter().formatSerialNumber(rawHexString);
+	}
+
+	public interface ISerialNumberFormatter {
+		String formatSerialNumber(String serialNumber);
+	}
+
+	public enum SerialNumberFormatter implements ISerialNumberFormatter {
+		HEX_STRING {
+			@Override
+			public String formatSerialNumber(String serialNumber) {
+				return "0x" + serialNumber;
+			}
+		},
+		LOWERCASE_COLONS {
+			@Override
+			public String formatSerialNumber(String serialNumber) {
+				String tmpSerialNumber = serialNumber.toLowerCase();
+				if (tmpSerialNumber.length() % 2 != 0) {
+					tmpSerialNumber = "0" + tmpSerialNumber;
+				}
+				char[] chars = tmpSerialNumber.toCharArray();
+				StringBuilder result = new StringBuilder();
+				for (int i = 0; i < chars.length; i++) {
+					result.append(chars[i]);
+					if (i % 2 == 1 && i < chars.length - 1) {
+						result.append(':');
+					}
+				}
+				return result.toString();
+			}
+		}
+	}
 }

--- a/kse/src/org/kse/gui/actions/PreferencesAction.java
+++ b/kse/src/org/kse/gui/actions/PreferencesAction.java
@@ -88,7 +88,8 @@ public class PreferencesAction extends ExitAction {
 				applicationSettings.isAutoUpdateCheckEnabled(),
 				applicationSettings.getAutoUpdateCheckInterval(),
 				applicationSettings.getKeyStoreTableColumns(),
-				applicationSettings.isShowHiddenFilesEnabled());
+				applicationSettings.isShowHiddenFilesEnabled(),
+				applicationSettings.getSerialNumberFormatter());
 		dPreferences.setLocationRelativeTo(frame);
 		dPreferences.setVisible(true);
 
@@ -115,6 +116,7 @@ public class PreferencesAction extends ExitAction {
 		applicationSettings.setAutoUpdateCheckEnabled(dPreferences.isAutoUpdateChecksEnabled());
 		applicationSettings.setAutoUpdateCheckInterval(dPreferences.getAutoUpdateChecksInterval());
 		applicationSettings.setShowHiddenFilesEnabled(dPreferences.isShowHiddenFilesEnabled());
+		applicationSettings.setSerialNumberFormatter(dPreferences.getSerialNumberFormatter());
 
 		UIManager.LookAndFeelInfo lookFeelInfo = dPreferences.getLookFeelInfo();
 		applicationSettings.setLookAndFeelClass(lookFeelInfo.getClassName());

--- a/kse/src/org/kse/gui/dialogs/DPreferences.java
+++ b/kse/src/org/kse/gui/dialogs/DPreferences.java
@@ -61,6 +61,7 @@ import javax.swing.border.EmptyBorder;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.kse.ApplicationSettings;
 import org.kse.crypto.SecurityProvider;
+import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CurrentDirectory;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.FileChooserFactory;
@@ -114,6 +115,8 @@ public class DPreferences extends JEscDialog {
 	private JLabel jlFileChooser;
 	private JCheckBox jcbShowHiddenFiles;
 	private JCheckBox jcbLookFeelDecorated;
+	private JLabel jlSerialNumberFormatter;
+	private JComboBox<X509CertUtil.SerialNumberFormatter> jcbSerialNumberFormatter;
 	private JPanel jpInternetProxy;
 	private JRadioButton jrbNoProxy;
 	private JRadioButton jrbSystemProxySettings;
@@ -159,6 +162,7 @@ public class DPreferences extends JEscDialog {
 	private boolean lookFeelDecorated;
 	private String language;
 	private boolean showHiddenFilesEnabled;
+	private X509CertUtil.SerialNumberFormatter serialNumberFormatter;
 
 	private boolean autoUpdateChecksEnabled;
 	private int autoUpdateChecksInterval;
@@ -226,10 +230,10 @@ public class DPreferences extends JEscDialog {
 	 * 			  Show hidden files in file chooser
 	 */
 	public DPreferences(JFrame parent, boolean useCaCertificates, File caCertificatesFile,
-			boolean useWinTrustedRootCertificates, boolean enableImportTrustedCertTrustCheck,
-			boolean enableImportCaReplyTrustCheck, PasswordQualityConfig passwordQualityConfig,
-			String defaultDN, String language, boolean autoUpdateChecksEnabled, int autoUpdateChecksInterval,
-			KeyStoreTableColumns kstColumns, boolean showHiddenFilesEnabled) {
+						boolean useWinTrustedRootCertificates, boolean enableImportTrustedCertTrustCheck,
+						boolean enableImportCaReplyTrustCheck, PasswordQualityConfig passwordQualityConfig,
+						String defaultDN, String language, boolean autoUpdateChecksEnabled, int autoUpdateChecksInterval,
+						KeyStoreTableColumns kstColumns, boolean showHiddenFilesEnabled, X509CertUtil.SerialNumberFormatter serialNumberFormatter) {
 		super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
 		this.useCaCertificates = useCaCertificates;
 		this.caCertificatesFile = caCertificatesFile;
@@ -242,6 +246,7 @@ public class DPreferences extends JEscDialog {
 		this.autoUpdateChecksEnabled = autoUpdateChecksEnabled;
 		this.autoUpdateChecksInterval = autoUpdateChecksInterval;
 		this.showHiddenFilesEnabled = showHiddenFilesEnabled;
+		this.serialNumberFormatter = serialNumberFormatter;
 		this.expiryWarnDays =  kstColumns.getExpiryWarnDays();
 		this.kstColumns = kstColumns;
 		initComponents();
@@ -480,6 +485,10 @@ public class DPreferences extends JEscDialog {
 		jcbShowHiddenFiles = new JCheckBox(res.getString("DPreferences.jcbShowHiddenFiles.text"));
 		jcbShowHiddenFiles.setSelected(showHiddenFilesEnabled);
 
+		jlSerialNumberFormatter = new JLabel(res.getString("DPreferences.jlSerialNumberFormatter.text"));
+		jcbSerialNumberFormatter = new JComboBox<>();
+		initSerialNumberFormatter();
+
 		// layout
 		jpUI = new JPanel();
 		jpUI.setLayout(new MigLayout("insets dialog", "20lp[][]", "20lp[][]"));
@@ -500,6 +509,8 @@ public class DPreferences extends JEscDialog {
 		jpUI.add(jsMinimumPasswordQuality, "wrap");
 		jpUI.add(jlFileChooser, "spanx, wrap");
 		jpUI.add(jcbShowHiddenFiles, "spanx, wrap");
+		jpUI.add(jlSerialNumberFormatter, "spanx, wrap");
+		jpUI.add(jcbSerialNumberFormatter, "spanx, wrap");
 
 		jcbEnableAutoUpdateChecks.addItemListener(new ItemListener() {
 			@Override
@@ -566,6 +577,15 @@ public class DPreferences extends JEscDialog {
 			jcbLanguage.addItem(languageItem);
 			if (languageItem.getIsoCode().equals(language)) {
 				jcbLanguage.setSelectedItem(languageItem);
+			}
+		}
+	}
+
+	private void initSerialNumberFormatter() {
+		for (X509CertUtil.SerialNumberFormatter formatter : X509CertUtil.SerialNumberFormatter.values()) {
+			jcbSerialNumberFormatter.addItem(formatter);
+			if (serialNumberFormatter == formatter) {
+				jcbSerialNumberFormatter.setSelectedItem(formatter);
 			}
 		}
 	}
@@ -889,6 +909,8 @@ public class DPreferences extends JEscDialog {
 
 		showHiddenFilesEnabled = jcbShowHiddenFiles.isSelected();
 
+		serialNumberFormatter = (X509CertUtil.SerialNumberFormatter) jcbSerialNumberFormatter.getSelectedItem();
+
 		// These may fail:
 		boolean returnValue = storeDefaultDN();
 		returnValue &= storeProxyPreferences();
@@ -1125,6 +1147,10 @@ public class DPreferences extends JEscDialog {
 		return showHiddenFilesEnabled;
 	}
 
+	public X509CertUtil.SerialNumberFormatter getSerialNumberFormatter() {
+		return serialNumberFormatter;
+	}
+
 	public boolean isAutoUpdateChecksEnabled() {
 		return autoUpdateChecksEnabled;
 	}
@@ -1246,7 +1272,8 @@ public class DPreferences extends JEscDialog {
 
 	public static void main(String[] args) throws Exception {
 		DPreferences dialog = new DPreferences(new javax.swing.JFrame(), true, new File(""), true, true, true,
-				new PasswordQualityConfig(true, true, 100), "", "en", true, 14, new KeyStoreTableColumns(), true);
+				new PasswordQualityConfig(true, true, 100), "", "en", true, 14, new KeyStoreTableColumns(), true,
+				X509CertUtil.SerialNumberFormatter.HEX_STRING);
 		DialogViewer.run(dialog);
 	}
 }

--- a/kse/src/org/kse/gui/dialogs/DViewCertificate.java
+++ b/kse/src/org/kse/gui/dialogs/DViewCertificate.java
@@ -572,7 +572,7 @@ public class DViewCertificate extends JEscDialog {
 
 				jdnIssuer.setDistinguishedName(X500NameUtils.x500PrincipalToX500Name(cert.getIssuerX500Principal()));
 
-				jtfSerialNumberHex.setText(X509CertUtil.getSerialNumberAsHex(cert));
+				jtfSerialNumberHex.setText(X509CertUtil.getFormattedSerialNumber(cert));
 				jtfSerialNumberHex.setCaretPosition(0);
 
 				jtfSerialNumberDec.setText(X509CertUtil.getSerialNumberAsDec(cert));

--- a/kse/src/org/kse/gui/dialogs/resources.properties
+++ b/kse/src/org/kse/gui/dialogs/resources.properties
@@ -259,6 +259,7 @@ DPreferences.jlCountryCode.text                            = Country (C):
 DPreferences.jlEmailAddress.text                           = Email (E):
 DPreferences.jlExpiryWarning.text                          = Warning time (in days) before certificate expiration
 DPreferences.jlFileChooser.text                            = File Chooser:
+DPreferences.jlSerialNumberFormatter.text                  = Serial Number Formatter:
 DPreferences.jlHttpHost.text                               = HTTP Proxy Host:
 DPreferences.jlHttpPort.text                               = Port:
 DPreferences.jlHttpsHost.text                              = HTTPS Proxy Host:

--- a/kse/src/org/kse/gui/dialogs/resources_de.properties
+++ b/kse/src/org/kse/gui/dialogs/resources_de.properties
@@ -256,6 +256,7 @@ DPreferences.jlCountryCode.text                            = Land (C):
 DPreferences.jlEmailAddress.text                           = E-Mail (E):
 DPreferences.jlExpiryWarning.text                          = Warnzeit (in Tagen) vor Zertifikatsablauf
 DPreferences.jlFileChooser.text                            = Dateiauswahldialog:
+DPreferences.jlSerialNumberFormatter.text                  = Formatierung der Seriennummer:
 DPreferences.jlHttpHost.text                               = HTTP-Proxy Server:
 DPreferences.jlHttpPort.text                               = Port:
 DPreferences.jlHttpsHost.text                              = HTTPS-Proxy Server:


### PR DESCRIPTION
This is my first shot to add formatting options for serial numbers. It's far from finished, but I would like to get some feedback if I'm heading into the right direction.

Some questions which I had during the process:

- Is X509CertUtil the right place for the formatter interface and enum?
- Where are the other places where a serial number should be formatted?
- Which variants should be implemented?
- Is the look&feel tab the right place for this setting?
- Which rules are used for formatting?

Currently, the enum name is displayed in the preferences. I would add a human readable title, and possibly a tooltip with an example of the formatted serial number.

Feedback is greatly appreciated, don't hold back :)