### PR TITLE
Fix Debian package lint warnings

### DIFF
--- a/kse/build.gradle
+++ b/kse/build.gradle
@@ -462,8 +462,10 @@ ospackage {
 
 	url "${website}"
 	summary "Multipurpose keystore and certificate tool"
-	packageGroup 'Security'
-	packageDescription 'KeyStore Explorer is a user friendly GUI application for creating, managing and examining keystores, keys, certificates, certificate requests, certificate revocation lists and more.'
+	packageGroup 'utils'
+	packageDescription 'KeyStore Explorer is a user friendly GUI application for creating,\n' +
+			'managing and examining keystores, keys, certificates, certificate requests,\n' +
+			'certificate revocation lists and more.'
 	license 'GPLv3+'
 	packager ''
 	vendor "${vendor}"
@@ -486,6 +488,7 @@ ospackage {
 		include '**/*.txt'
 		into 'licenses'
 		fileType LICENSE
+		fileMode 0644
 	}
 	from(iconsDir) {
 		include '**/kse_*.png'
@@ -509,6 +512,7 @@ ospackage {
 	link('/usr/share/applications/kse.desktop', '/opt/kse/kse.desktop', 0644)
 	for (size in [16, 32, 48, 128, 256, 512]) {
 		link("/usr/share/icons/hicolor/${size}x${size}/apps/kse.png", "/opt/kse/icons/kse_${size}.png", 0644)
+		fileMode 0644
 	}
 }
 

--- a/kse/build.gradle
+++ b/kse/build.gradle
@@ -481,9 +481,6 @@ ospackage {
 	from(configurations.runtimeClasspath.files) {
 		into 'lib'
 	}
-	from('lib') {
-		into 'lib'
-	}
 	from(licensesDir) {
 		include '**/*.txt'
 		into 'licenses'


### PR DESCRIPTION
The `gradle buildDeb` produces the `build/distributions/kse_all.deb` package.
You may open in in the `gdebi` GUI programs and open Linitan tab. It shows a lot of warnings and problems.

The first one is that the Section: Security doesn't exists i Debian. You may check the existing sections here https://packages.debian.org/stable/. So I changed it to Utils.

The package description in Debian should have not longer than 80 chars in a line.

Basically that all should be fixed in the gradle-ospackage-plugin but I don't really see any reason to use it at all. We can replace it with the Debian native `debian` folder.

