### PR TITLE
Issue_546: General Names (SAN, AKI, IAN, CDP) - remove sorting (preserve user order)

### DIFF
--- a/kse/src/main/java/org/kse/gui/crypto/generalname/GeneralNamesTableModel.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/GeneralNamesTableModel.java
@@ -21,8 +21,6 @@ package org.kse.gui.crypto.generalname;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -30,7 +28,6 @@ import javax.swing.table.AbstractTableModel;
 
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
-import org.kse.crypto.x509.GeneralNameUtil;
 
 /**
  * The table model used to display general names.
@@ -62,7 +59,6 @@ public class GeneralNamesTableModel extends AbstractTableModel {
         GeneralName[] generalNamesArray = generalNames.getNames();
 
         data = new ArrayList<>(Arrays.asList(generalNamesArray));
-        data.sort(new GeneralNameComparator());
 
         fireTableDataChanged();
     }
@@ -140,7 +136,6 @@ public class GeneralNamesTableModel extends AbstractTableModel {
      */
     public void addRow(GeneralName generalName) {
         data.add(generalName);
-        data.sort(new GeneralNameComparator());
         fireTableDataChanged();
     }
 
@@ -161,13 +156,5 @@ public class GeneralNamesTableModel extends AbstractTableModel {
      */
     public List<GeneralName> getData() {
         return data;
-    }
-
-    static class GeneralNameComparator implements Comparator<GeneralName> {
-        @Override
-        public int compare(GeneralName name1, GeneralName name2) {
-            return GeneralNameUtil.safeToString(name1, false)
-                                  .compareToIgnoreCase(GeneralNameUtil.safeToString(name2, false));
-        }
     }
 }

--- a/kse/src/main/java/org/kse/gui/crypto/generalname/GeneralNamesTableModel.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/GeneralNamesTableModel.java
@@ -21,6 +21,7 @@ package org.kse.gui.crypto.generalname;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -28,6 +29,7 @@ import javax.swing.table.AbstractTableModel;
 
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.kse.crypto.x509.GeneralNameUtil;
 
 /**
  * The table model used to display general names.
@@ -156,5 +158,13 @@ public class GeneralNamesTableModel extends AbstractTableModel {
      */
     public List<GeneralName> getData() {
         return data;
+    }
+
+    static class GeneralNameComparator implements Comparator<GeneralName> {
+        @Override
+        public int compare(GeneralName name1, GeneralName name2) {
+            return GeneralNameUtil.safeToString(name1, false)
+                                  .compareToIgnoreCase(GeneralNameUtil.safeToString(name2, false));
+        }
     }
 }

--- a/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
@@ -42,7 +42,6 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
-import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
@@ -141,10 +140,6 @@ public class JGeneralNames extends JPanel {
 
         GeneralNamesTableModel generalNamesTableModel = new GeneralNamesTableModel();
         jtGeneralNames = new JKseTable(generalNamesTableModel);
-
-        TableRowSorter<GeneralNamesTableModel> sorter = new TableRowSorter<>(generalNamesTableModel);
-        sorter.setComparator(0, new GeneralNamesTableModel.GeneralNameComparator());
-        jtGeneralNames.setRowSorter(sorter);
 
         jtGeneralNames.setShowGrid(false);
         jtGeneralNames.setRowMargin(0);

--- a/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
@@ -42,6 +42,7 @@ import javax.swing.JScrollPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
+import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
@@ -140,6 +141,10 @@ public class JGeneralNames extends JPanel {
 
         GeneralNamesTableModel generalNamesTableModel = new GeneralNamesTableModel();
         jtGeneralNames = new JKseTable(generalNamesTableModel);
+
+        TableRowSorter<GeneralNamesTableModel> sorter = new TableRowSorter<>(generalNamesTableModel);
+        sorter.setComparator(0, new GeneralNamesTableModel.GeneralNameComparator());
+        jtGeneralNames.setRowSorter(sorter);
 
         jtGeneralNames.setShowGrid(false);
         jtGeneralNames.setRowMargin(0);


### PR DESCRIPTION
#546: General Names (SAN, AKI, IAN, CDP) - remove sorting

Users can define their own order, so we don't need to sort automatically.
Ideally, we can provide a way to reorder items in future (up and down arrows to move records across the table).

**Important observation**
- there is a potential issue - "General Name" column is sortable, so users can add sorting on the column, but sorting doesn't affect the final saved result (say you created records "a", "c", "b" and after that sorted DESC -> resulting to "c", "b", "a"; but on pressing "OK", model still has "a", "c", "b", so user may be confused)
- it's not difficult to fix (e.g. we can add "RowSortListener" for the table sorter), but I would think twice before doing that for reasons:
  - I'm not sure if users would really expect that sorted results will be saved - usually, sorting doesn't impact saved data
  - probably, the easiest option would be just to remove sorting feature from "General Name" column
- issue with sorting exists even in current version (without the fix) - we can sort DESC, but data will be sort in ascending order

**Testing**
As I see `org.kse.gui` package is not considered as a candidate for Unit Tests, thus I tested manually (below are the corresponding screenshots):
![image](https://github.com/user-attachments/assets/0808014c-26d6-467f-8481-1560f7490501)
![image](https://github.com/user-attachments/assets/917a3f6a-69fb-4441-bf7b-05781f49340b)
![image](https://github.com/user-attachments/assets/ea6166fe-e0c5-4f08-94f4-4e80cfa72771)
![image](https://github.com/user-attachments/assets/09a97c1b-7bbd-46ff-9425-8c371c4f2657)
![image](https://github.com/user-attachments/assets/d143c8fe-a9bc-4438-85fc-7c11b8f8c979)
![image](https://github.com/user-attachments/assets/a8fe2496-bcdc-4dab-9793-cbd3f581f7ee)
![image](https://github.com/user-attachments/assets/75378c43-c9bb-4431-bf8c-491b0e926917)

