### PR TITLE
KeyStore Explorer – ML-DSA-44/65/87 support for BC based KeyStores

### DIFF
--- a/kse/build.gradle
+++ b/kse/build.gradle
@@ -110,7 +110,7 @@ configurations {
 }
 
 dependencies {
-	implementation('org.bouncycastle:bcpkix-jdk18on:1.80')
+	implementation('org.bouncycastle:bcpkix-jdk18on:1.81')
 	implementation('commons-io:commons-io:2.17.0')
 	implementation('com.miglayout:miglayout-swing:11.4.2')
 	implementation('com.formdev:flatlaf:3.5.4:no-natives')

--- a/kse/src/main/java/org/kse/crypto/ecc/CurveSet.java
+++ b/kse/src/main/java/org/kse/crypto/ecc/CurveSet.java
@@ -24,7 +24,6 @@ import static org.kse.version.JavaVersion.JRE_VERSION_15;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
-import java.util.Iterator;
 import java.util.List;
 
 import org.bouncycastle.asn1.nist.NISTNamedCurves;
@@ -61,7 +60,7 @@ public enum CurveSet {
         sets.add(ANSI_X9_62.visibleName);
         sets.add(NIST.visibleName);
         sets.add(SEC.visibleName);
-        if (EccUtil.isBouncyCastleKeyStore(keyStoreType)) {
+        if (KeyStoreType.isBouncyCastleKeyStore(keyStoreType)) {
             sets.add(TELETRUST.visibleName);
         }
         sets.add(ED.visibleName);
@@ -78,10 +77,10 @@ public enum CurveSet {
         sets.add(ANSI_X9_62);
         sets.add(NIST);
         sets.add(SEC);
-        if (EccUtil.isBouncyCastleKeyStore(keyStoreType)) {
+        if (KeyStoreType.isBouncyCastleKeyStore(keyStoreType)) {
             sets.add(TELETRUST);
         }
-        if (EccUtil.isBouncyCastleKeyStore(keyStoreType) || JavaVersion.getJreVersion().isAtLeast(JRE_VERSION_15)) {
+        if (KeyStoreType.isBouncyCastleKeyStore(keyStoreType) || JavaVersion.getJreVersion().isAtLeast(JRE_VERSION_15)) {
             sets.add(ED);
         }
         return sets;

--- a/kse/src/main/java/org/kse/crypto/ecc/EccUtil.java
+++ b/kse/src/main/java/org/kse/crypto/ecc/EccUtil.java
@@ -166,18 +166,7 @@ public class EccUtil {
      * @return True, if there are EC curves available
      */
     public static boolean isECAvailable(KeyStoreType keyStoreType) {
-        return (sunECProviderAvailable) || isBouncyCastleKeyStore(keyStoreType);
-    }
-
-    /**
-     * Is the given KeyStoreType backed by the BC provider?
-     *
-     * @param keyStoreType KeyStoreType to check
-     * @return True, if KeyStoreType is backed by the BC provider
-     */
-    public static boolean isBouncyCastleKeyStore(KeyStoreType keyStoreType) {
-        return (keyStoreType == KeyStoreType.BKS || keyStoreType == KeyStoreType.UBER ||
-                keyStoreType == KeyStoreType.BCFKS);
+        return (sunECProviderAvailable) || KeyStoreType.isBouncyCastleKeyStore(keyStoreType);
     }
 
     /**
@@ -190,7 +179,7 @@ public class EccUtil {
     public static boolean isCurveAvailable(String curveName, KeyStoreType keyStoreType) {
 
         // BC provides all curves
-        if (isBouncyCastleKeyStore(keyStoreType) || EdDSACurves.ED25519.jce().equalsIgnoreCase(curveName) ||
+        if (KeyStoreType.isBouncyCastleKeyStore(keyStoreType) || EdDSACurves.ED25519.jce().equalsIgnoreCase(curveName) ||
             EdDSACurves.ED448.jce().equalsIgnoreCase(curveName)) {
             return true;
         }

--- a/kse/src/main/java/org/kse/crypto/keypair/KeyPairType.java
+++ b/kse/src/main/java/org/kse/crypto/keypair/KeyPairType.java
@@ -20,6 +20,7 @@
 package org.kse.crypto.keypair;
 
 import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Enumeration of Key Pair Types supported by the KeyPairUtil class.
@@ -31,12 +32,17 @@ public enum KeyPairType {
     ECDSA("ECDSA", "1.2.840.10045.2.1", 160, 571, 32),
     EDDSA("EdDSA", "", 256, 456, 200), // for Java >= 15 (there is no specific OID for EdDSA)
     ED25519("Ed25519", "1.3.101.112", 256, 256, 0), // BC has separate key pair types for the two EdDSA types
-    ED448("Ed448", "1.3.101.113", 456, 456, 0);
+    ED448("Ed448", "1.3.101.113", 456, 456, 0),
+
+    MLDSA44("ML-DSA-44", "2.16.840.1.101.3.4.3.17", 10_496, 10_496, 0),
+    MLDSA65("ML-DSA-65", "2.16.840.1.101.3.4.3.18", 15_616, 15_616, 0),
+    MLDSA87("ML-DSA-87", "2.16.840.1.101.3.4.3.19", 20_736, 20_736, 0);
 
     /**
      * Set of all EC key pair types (EC, ECDSA, EDDSA, ED25519, ED448)
      */
-    public static final EnumSet<KeyPairType> EC_TYPES_SET = EnumSet.of(EC, ECDSA, EDDSA, ED25519, ED448);
+    public static final Set<KeyPairType> EC_TYPES_SET = EnumSet.of(EC, ECDSA, EDDSA, ED25519, ED448);
+    private static final Set<KeyPairType> MLDSA_TYPES_SET = EnumSet.of(MLDSA44, MLDSA65, MLDSA87);
 
     private final String jce;
     private final String oid;
@@ -111,6 +117,10 @@ public enum KeyPairType {
         }
 
         return null;
+    }
+
+    public static boolean isMlDSA(KeyPairType keyPairType) {
+        return MLDSA_TYPES_SET.contains(keyPairType);
     }
 
     /**

--- a/kse/src/main/java/org/kse/crypto/keypair/KeyPairUtil.java
+++ b/kse/src/main/java/org/kse/crypto/keypair/KeyPairUtil.java
@@ -139,7 +139,18 @@ public final class KeyPairUtil {
         }
     }
 
-
+    /**
+     * Generates an ML-DSA key pair
+     * <ul>
+     *     <li>
+     *     see {@link org.kse.crypto.keypair.KeyPairType#isMlDSA(KeyPairType)}
+     *     </li>
+     * <ul>
+     * @param keyPairType must be an mldsa key pair
+     * @param provider the provider must support ML-DSA, if null defaults to BC
+     * @return
+     * @throws CryptoException
+     */
     public static KeyPair generateMLDSAKeyPair(KeyPairType keyPairType, Provider provider)
             throws CryptoException {
         try {

--- a/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
@@ -62,6 +62,17 @@ public enum KeyStoreType {
     }
 
     /**
+     * Is the given KeyStoreType backed by the BC provider?
+     *
+     * @param keyStoreType KeyStoreType to check
+     * @return True, if KeyStoreType is backed by the BC provider
+     */
+    public static boolean isBouncyCastleKeyStore(KeyStoreType keyStoreType) {
+        return (keyStoreType == BKS || keyStoreType == UBER ||
+                keyStoreType == BCFKS);
+    }
+
+    /**
      * Get KeyStore type JCE name.
      *
      * @return JCE name
@@ -122,6 +133,10 @@ public enum KeyStoreType {
      */
     public boolean supportsECC() {
         return EccUtil.isECAvailable(this);
+    }
+
+    public boolean supportMLDSA() {
+        return isBouncyCastleKeyStore(this);
     }
 
     /**

--- a/kse/src/main/java/org/kse/crypto/privatekey/MsPvkUtil.java
+++ b/kse/src/main/java/org/kse/crypto/privatekey/MsPvkUtil.java
@@ -38,11 +38,14 @@ import java.security.spec.DSAPrivateKeySpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.kse.crypto.CryptoException;
+import org.kse.crypto.keypair.KeyPairType;
+import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.utilities.PRNG;
 import org.kse.utilities.io.UnsignedUtil;
@@ -164,6 +167,9 @@ public class MsPvkUtil {
 
     // Length of a private key blob header in bytes
     private static final int BLOB_HEADER_LENGTH = 8;
+
+    private static final Set<KeyPairType> PVK_SUPPORTED_KEYPAIR = Set.of(
+            KeyPairType.RSA, KeyPairType.DSA);
 
     /*
      * Length of PVK read buffer used when creating PVK encoding This should be
@@ -477,6 +483,14 @@ public class MsPvkUtil {
     public static byte[] getEncrypted(DSAPrivateKey privateKey, Password password, boolean strong)
             throws CryptoException {
         return getEncryptedInternal(privateKey, PVK_KEY_SIGNATURE, password, strong);
+    }
+
+    /**
+     * Legacy format only supported for RSA and DSA keys
+     */
+    public static boolean isPVKFormatSupported(PrivateKey privateKey) {
+        KeyPairType keyPairType = KeyPairUtil.getKeyPairType(privateKey);
+        return PVK_SUPPORTED_KEYPAIR.contains(keyPairType);
     }
 
     private static byte[] getEncryptedInternal(PrivateKey privateKey, int keyType, Password password, boolean strong)

--- a/kse/src/main/java/org/kse/crypto/privatekey/OpenSslPvkUtil.java
+++ b/kse/src/main/java/org/kse/crypto/privatekey/OpenSslPvkUtil.java
@@ -38,6 +38,7 @@ import java.security.spec.DSAPrivateKeySpec;
 import java.security.spec.RSAPrivateCrtKeySpec;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -60,6 +61,8 @@ import org.kse.crypto.CryptoException;
 import org.kse.crypto.digest.DigestType;
 import org.kse.crypto.digest.DigestUtil;
 import org.kse.crypto.ecc.EccUtil;
+import org.kse.crypto.keypair.KeyPairType;
+import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.utilities.PRNG;
 import org.kse.utilities.pem.PemAttribute;
@@ -137,6 +140,9 @@ public class OpenSslPvkUtil {
 
     // DEK-Info PEM headere attribute value template (pbe algorithm,salt)
     private static final String DEK_INFO_ATTR_VALUE_TEMPLATE = "{0},{1}";
+
+    private static final Set<KeyPairType> OPEN_SSL_SUPPORTED_KEYPAIR = Set.of(
+            KeyPairType.RSA, KeyPairType.DSA, KeyPairType.EC, KeyPairType.ECDSA);
 
     private OpenSslPvkUtil() {
     }
@@ -613,4 +619,13 @@ public class OpenSslPvkUtil {
                     ex);
         }
     }
+
+    /**
+     * Legacy format only supported for RSA, DSA, and EC curves (except Edwards)
+     */
+    public static boolean isOpenSSLFormatSupported(PrivateKey privateKey) {
+        KeyPairType keyPairType = KeyPairUtil.getKeyPairType(privateKey);
+        return OPEN_SSL_SUPPORTED_KEYPAIR.contains(keyPairType);
+    }
+
 }

--- a/kse/src/main/java/org/kse/crypto/signing/SignatureType.java
+++ b/kse/src/main/java/org/kse/crypto/signing/SignatureType.java
@@ -86,7 +86,12 @@ public enum SignatureType {
 
 	// EdDSA
 	ED25519("Ed25519", EdDSACurves.ED25519.oid().getId(), SHA512, "SignatureType.Ed25519"),
-	ED448("Ed448", EdDSACurves.ED448.oid().getId(), SHAKE256, "SignatureType.Ed448");
+	ED448("Ed448", EdDSACurves.ED448.oid().getId(), SHAKE256, "SignatureType.Ed448"),
+
+    // ML-DSA (“pure”)
+    MLDSA44("ML-DSA-44", "2.16.840.1.101.3.4.3.17", SHAKE256, "SignatureType.MlDsa44"),
+    MLDSA65("ML-DSA-65", "2.16.840.1.101.3.4.3.18", SHAKE256, "SignatureType.MlDsa65"),
+    MLDSA87("ML-DSA-87", "2.16.840.1.101.3.4.3.19", SHAKE256, "SignatureType.MlDsa87");
 	// @formatter:on
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/crypto/signing/resources");

--- a/kse/src/main/java/org/kse/gui/KeyStoreTableCellRend.java
+++ b/kse/src/main/java/org/kse/gui/KeyStoreTableCellRend.java
@@ -157,7 +157,7 @@ public class KeyStoreTableCellRend extends DefaultTableCellRenderer {
                     cell.setHorizontalAlignment(LEFT);
                 } else {
                     if (value instanceof Integer) {
-                        if (((Integer) value < 10000) && ((Integer) value >= 0)) {
+                        if (((Integer) value < 100_000) && ((Integer) value >= 0)) {
                             cell.setText(String.valueOf(value));
                         } else {
                             cell.setText("X" + String.format("%x", value));

--- a/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
@@ -50,6 +50,7 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
     private KeyStoreType newType;
     private boolean warnNoChangeKey;
     private boolean warnNoECC;
+    private boolean warnNoMLDSA;
 
     /**
      * Construct action.
@@ -146,6 +147,7 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
 
         // Only warn the user once about key entries not being carried over by the change
         warnNoECC = false;
+        warnNoMLDSA = false;
     }
 
     private boolean copyKeyPairEntry(KeyStoreType newKeyStoreType, KeyStoreState currentState, KeyStore currentKeyStore,
@@ -175,6 +177,11 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
                 // show warning and abort change or just skip depending on user choice
                 return showWarnNoECC();
             }
+        }
+
+        if (KeyStoreUtil.isMLDSAKeyPair(alias, currentKeyStore)
+                && !newKeyStoreType.supportMLDSA()) {
+            return showWarnNoMLDSA();
         }
 
         newKeyStore.setKeyEntry(alias, privateKey, password.toCharArray(), certificateChain);
@@ -219,6 +226,20 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
             }
         }
         // do not add this entry to new key store
+        return true;
+    }
+
+    private boolean showWarnNoMLDSA() {
+        if (!warnNoMLDSA) {
+            warnNoMLDSA = true;
+            int selected = JOptionPane.showConfirmDialog(frame,
+                    res.getString("ChangeTypeAction.WarnNoMLDSA.message"),
+                    res.getString("ChangeTypeAction.ChangeKeyStoreType.Title"), JOptionPane.YES_NO_OPTION);
+            if (selected != JOptionPane.YES_OPTION) {
+                // user wants to abort
+                return false;
+            }
+        }
         return true;
     }
 

--- a/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
@@ -109,15 +109,19 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
             int keyPairSizeDSA = preferences.getKeyGenerationDefaults().getKeyPairSizeDSA();
             String keyPairCurveSet = preferences.getKeyGenerationDefaults().getEcCurveSet();
             String keyPairCurveName = preferences.getKeyGenerationDefaults().getEcCurveName();
+            KeyPairType mlDSAKeyPairType = preferences.getKeyGenerationDefaults()
+                    .getMLDSAKeyPairType();
 
             KeyStore activeKeyStore = kseFrame.getActiveKeyStore();
             KeyStoreType activeKeyStoreType = KeyStoreType.resolveJce(activeKeyStore.getType());
             KeyStoreHistory history = kseFrame.getActiveKeyStoreHistory();
             Provider provider = history.getExplicitProvider();
 
-            DGenerateKeyPair dGenerateKeyPair = new DGenerateKeyPair(frame, activeKeyStoreType, keyPairType,
-                                                                     keyPairSizeRSA, keyPairSizeDSA, keyPairCurveSet,
-                                                                     keyPairCurveName);
+            DGenerateKeyPair dGenerateKeyPair = new DGenerateKeyPair(
+                    frame, activeKeyStoreType, keyPairType,
+                    keyPairSizeRSA, keyPairSizeDSA, keyPairCurveSet, keyPairCurveName)
+                    .setMLDSAKeyPairType(mlDSAKeyPairType);
+
             dGenerateKeyPair.setLocationRelativeTo(frame);
             dGenerateKeyPair.setVisible(true);
 
@@ -136,8 +140,16 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
             preferences.getKeyGenerationDefaults().setKeyPairSizeDSA(keyPairSizeDSA);
             preferences.getKeyGenerationDefaults().setEcCurveSet(keyPairCurveSet);
             preferences.getKeyGenerationDefaults().setEcCurveName(keyPairCurveName);
+            preferences.getKeyGenerationDefaults().setMLDSAKeyPairType(keyPairType);
 
-            KeyPair keyPair = generateKeyPair(keyPairType, keyPairSizeRSA, keyPairSizeDSA, keyPairCurveName, provider);
+            KeyPair keyPair = generateKeyPair(
+                    keyPairType,
+                    keyPairSizeRSA,
+                    keyPairSizeDSA,
+                    keyPairCurveName,
+                    provider
+            );
+
             if (keyPair == null) {
                 return "";
             }
@@ -255,6 +267,11 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
             break;
         case DSA:
             dGeneratingKeyPair = new DGeneratingKeyPair(frame, keyPairType, keyPairSizeDSA, provider);
+            break;
+        case MLDSA44:
+        case MLDSA65:
+        case MLDSA87:
+            dGeneratingKeyPair = new DGeneratingKeyPair(frame, keyPairType, provider);
             break;
         case EC:
         case ECDSA:

--- a/kse/src/main/java/org/kse/gui/dialogs/DGeneratingKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGeneratingKeyPair.java
@@ -95,6 +95,20 @@ public class DGeneratingKeyPair extends JEscDialog {
      *
      * @param parent      The parent frame
      * @param keyPairType The key pair generation type
+     */
+    public DGeneratingKeyPair(JFrame parent, KeyPairType keyPairType, Provider provider) {
+        super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
+        this.keyPairType = keyPairType;
+        this.provider = provider;
+        initComponents();
+    }
+
+
+    /**
+     * Creates a new DGeneratingKeyPair dialog.
+     *
+     * @param parent      The parent frame
+     * @param keyPairType The key pair generation type
      * @param curveName   The name of the curve to create
      */
     public DGeneratingKeyPair(JFrame parent, KeyPairType keyPairType, String curveName, Provider provider) {
@@ -197,6 +211,11 @@ public class DGeneratingKeyPair extends JEscDialog {
                 case RSA:
                 case DSA:
                     keyPair = KeyPairUtil.generateKeyPair(keyPairType, keySize, provider);
+                    break;
+                case MLDSA44:
+                case MLDSA65:
+                case MLDSA87:
+                    keyPair = KeyPairUtil.generateMLDSAKeyPair(keyPairType, provider);
                     break;
                 case EC:
                 case ECDSA:

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
@@ -363,11 +363,8 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
                 res.getString("DViewAsymmetricKeyFields.jltFields.PublicKey.text"),
                 getHexString(raw)));
 
-        try {
-            MLDSAPublicKey publicKey = (MLDSAPublicKey) key;
-            populateDetailedFields(publicKey, fields);
-        } catch (Exception e) {
-        }
+        MLDSAPublicKey publicKey = (MLDSAPublicKey) key;
+        populateDetailedFields(publicKey, fields);
         return fields.toArray(Field[]::new);
     }
 
@@ -389,11 +386,7 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
                 getHexString(privateKey.getPrivateData())));
 
         // Add detailed fields
-        try {
-            populateDetailedFields(privateKey, fields);
-        } catch (Exception e) {
-            // ignored
-        }
+        populateDetailedFields(privateKey, fields);
 
         return fields.toArray(Field[]::new);
     }
@@ -417,10 +410,6 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
     }
 
     private void populateDetailedFields(MLDSAPublicKey publicKey, List<Field> fields) {
-        if (!(key instanceof MLDSAPublicKey)) {
-            return;
-        }
-
         KeyPairType keyPairType = KeyPairUtil.getKeyPairType(publicKey);
         MLDSAParameters params = getMLDSAParameters(keyPairType);
         if (params == null) {
@@ -442,10 +431,6 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
     }
 
     private void populateDetailedFields(MLDSAPrivateKey privateKey, List<Field> fields) {
-        if (!(key instanceof MLDSAPrivateKey)) {
-            return;
-        }
-
         KeyPairType keyPairType = KeyPairUtil.getKeyPairType(privateKey);
         MLDSAParameters params = getMLDSAParameters(keyPairType);
         if (params == null) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
@@ -47,7 +47,8 @@ import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
+import org.bouncycastle.jcajce.interfaces.EdDSAPrivateKey;
+import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
@@ -299,8 +300,9 @@ public class DViewPrivateKey extends JEscDialog {
         jtaEncoded.setText(new BigInteger(1, privateKey.getEncoded()).toString(16).toUpperCase());
         jtaEncoded.setCaretPosition(0);
 
-        jbFields.setEnabled((privateKey instanceof RSAPrivateKey) || (privateKey instanceof DSAPrivateKey) ||
-                            (privateKey instanceof ECPrivateKey) || (privateKey instanceof BCEdDSAPrivateKey));
+        jbFields.setEnabled((privateKey instanceof RSAPrivateKey) || (privateKey instanceof DSAPrivateKey)
+                || (privateKey instanceof ECPrivateKey) || (privateKey instanceof EdDSAPrivateKey)
+                || (privateKey instanceof MLDSAPrivateKey));
     }
 
     private void pemEncodingPressed() {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPublicKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPublicKey.java
@@ -46,6 +46,7 @@ import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
+import org.bouncycastle.jcajce.interfaces.MLDSAPublicKey;
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
@@ -271,8 +272,9 @@ public class DViewPublicKey extends JEscDialog {
         jcfFingerprint.setPublicKey(publicKey);
         jcfFingerprint.setFingerprintAlg(preferences.getPublicKeyFingerprintAlgorithm());
 
-        jbFields.setEnabled((publicKey instanceof RSAPublicKey) || (publicKey instanceof DSAPublicKey) ||
-                            (publicKey instanceof ECPublicKey) || (publicKey instanceof BCEdDSAPublicKey));
+        jbFields.setEnabled((publicKey instanceof RSAPublicKey) || (publicKey instanceof DSAPublicKey)
+                || (publicKey instanceof ECPublicKey) || (publicKey instanceof BCEdDSAPublicKey)
+                || publicKey instanceof MLDSAPublicKey);
     }
 
     private void pemEncodingPressed() {

--- a/kse/src/main/java/org/kse/gui/dialogs/DialogHelper.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DialogHelper.java
@@ -81,6 +81,15 @@ public class DialogHelper {
         case ED448:
             sigAlgs = Collections.singletonList(SignatureType.ED448);
             break;
+        case MLDSA44:
+            sigAlgs = Collections.singletonList(SignatureType.MLDSA44);
+            break;
+        case MLDSA65:
+            sigAlgs = List.of(SignatureType.MLDSA65);
+            break;
+        case MLDSA87:
+            sigAlgs = Collections.singletonList(SignatureType.MLDSA87);
+            break;
         case RSA:
         default:
             try {

--- a/kse/src/main/java/org/kse/gui/dialogs/DialogHelper.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DialogHelper.java
@@ -85,7 +85,7 @@ public class DialogHelper {
             sigAlgs = Collections.singletonList(SignatureType.MLDSA44);
             break;
         case MLDSA65:
-            sigAlgs = List.of(SignatureType.MLDSA65);
+            sigAlgs = Collections.singletonList(SignatureType.MLDSA65);
             break;
         case MLDSA87:
             sigAlgs = Collections.singletonList(SignatureType.MLDSA87);

--- a/kse/src/main/java/org/kse/gui/dialogs/MLDSAKeySelector.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/MLDSAKeySelector.java
@@ -14,6 +14,25 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.ResourceBundle;
 
+/**
+ * UI elements used by {@link  org.kse.gui.dialogs.DGenerateKeyPair}
+ * to generate MLDSA key pairs
+ * <p>
+ * Holds a radio button and combo box for picking an ML-DSA {@link KeyPairType},
+ * enabling/disabling the combo automatically.
+ * </p>
+ *
+ * <pre>
+ * {@code
+ * MLDSAKeySelector mlDsa = new MLDSAKeySelector(group);
+ * mlDsa.add(contentPane);
+ *
+ * if (mlDsa.isSelected()) { // later, when OK pressed
+ *     KeyPairType type = mlDsa.getKeyPairType();
+ * }
+ * }
+ * </pre>
+ */
 public class MLDSAKeySelector implements Serializable {
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(
             "org/kse/gui/dialogs/resources");

--- a/kse/src/main/java/org/kse/gui/dialogs/MLDSAKeySelector.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/MLDSAKeySelector.java
@@ -1,0 +1,97 @@
+package org.kse.gui.dialogs;
+
+import org.kse.crypto.keypair.KeyPairType;
+import org.kse.gui.PlatformUtil;
+
+import javax.swing.ButtonGroup;
+import javax.swing.DefaultComboBoxModel;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JRadioButton;
+import java.awt.Container;
+import java.awt.event.ItemListener;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.ResourceBundle;
+
+public class MLDSAKeySelector implements Serializable {
+    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(
+            "org/kse/gui/dialogs/resources");
+
+    private static final long serialVersionUID = 1998L;
+
+    protected JRadioButton jRadioButton;
+    protected JLabel jLabelKeyType;
+    protected JComboBox<String> jComboBoxKeyType;
+
+
+    public MLDSAKeySelector(ButtonGroup buttonGroup) {
+
+        jRadioButton = new JRadioButton(RESOURCE_BUNDLE.getString("MLDSAKeySelector.jRadioButton.text"));
+        jRadioButton.setToolTipText(RESOURCE_BUNDLE.getString("MLDSAKeySelector.jRadioButton.tooltip"));
+        PlatformUtil.setMnemonic(
+                jRadioButton, RESOURCE_BUNDLE.getString("MLDSAKeySelector.jRadioButton.mnemonic").charAt(0));
+
+        jLabelKeyType = new JLabel(RESOURCE_BUNDLE.getString("MLDSAKeySelector.jLabelKeyType.tooltip"));
+
+
+        jComboBoxKeyType = new JComboBox<>();
+        jComboBoxKeyType.setToolTipText(RESOURCE_BUNDLE.getString("MLDSAKeySelector.jComboBoxKeyType.tooltip"));
+
+
+        String[] names = Arrays.stream(KeyPairType.values())
+                .filter(KeyPairType::isMlDSA)
+                .map(KeyPairType::jce)
+                .toArray(String[]::new);
+
+        jComboBoxKeyType.setModel(new DefaultComboBoxModel<>(names));
+        jRadioButton.setEnabled(true);
+        jRadioButton.addItemListener(event -> enableDisableElements());
+        this.setSelected(true);
+        if (buttonGroup != null) {
+            buttonGroup.add(jRadioButton);
+        }
+    }
+
+    public void add(Container pane) {
+        if (pane == null) {
+            return;
+        }
+        pane.add(jRadioButton, "");
+        pane.add(jLabelKeyType, "");
+        pane.add(jComboBoxKeyType, "growx, wrap");
+    }
+
+    public void enableDisableElements() {
+        jComboBoxKeyType.setEnabled(jRadioButton.isSelected());
+    }
+
+    public void setPreferredKeyType(KeyPairType keyType) {
+        if (KeyPairType.isMlDSA(keyType)) {
+            jComboBoxKeyType.setSelectedItem(keyType.jce());
+        }
+    }
+
+    public void addItemListener(ItemListener itemListener) {
+        jRadioButton.addItemListener(itemListener);
+    }
+
+    public boolean isSelected() {
+        return jRadioButton.isSelected();
+    }
+
+    public void setEnabled(boolean enabled) {
+        jRadioButton.setEnabled(enabled);
+        enableDisableElements();
+    }
+
+    public void setSelected(boolean selected) {
+        jRadioButton.setSelected(selected);
+        enableDisableElements();
+    }
+
+    public KeyPairType getKeyPairType() {
+        return KeyPairType.resolveJce((String) jComboBoxKeyType.getSelectedItem());
+    }
+
+}

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyType.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyType.java
@@ -43,10 +43,12 @@ import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 
 import org.kse.crypto.CryptoException;
-import org.kse.crypto.jwk.JwkExporter;
 import org.kse.crypto.KeyInfo;
+import org.kse.crypto.jwk.JwkExporter;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.keypair.KeyPairUtil;
+import org.kse.crypto.privatekey.MsPvkUtil;
+import org.kse.crypto.privatekey.OpenSslPvkUtil;
 import org.kse.gui.components.JEscDialog;
 import org.kse.gui.PlatformUtil;
 
@@ -112,18 +114,12 @@ public class DExportPrivateKeyType extends JEscDialog {
         jrbPvk = new JRadioButton(res.getString("DExportPrivateKeyType.jrbPvk.text"));
         PlatformUtil.setMnemonic(jrbPvk, res.getString("DExportPrivateKeyType.jrbPvk.mnemonic").charAt(0));
         jrbPvk.setToolTipText(res.getString("DExportPrivateKeyType.jrbPvk.tooltip"));
-        if (keyPairType == KeyPairType.EC || keyPairType == KeyPairType.ECDSA || keyPairType == KeyPairType.EDDSA ||
-            keyPairType == KeyPairType.ED25519 || keyPairType == KeyPairType.ED448) {
-            jrbPvk.setEnabled(false);
-        }
+        jrbPvk.setEnabled(MsPvkUtil.isPVKFormatSupported(privateKey));
 
         jrbOpenSsl = new JRadioButton(res.getString("DExportPrivateKeyType.jrbOpenSsl.text"));
         PlatformUtil.setMnemonic(jrbOpenSsl, res.getString("DExportPrivateKeyType.jrbOpenSsl.mnemonic").charAt(0));
         jrbOpenSsl.setToolTipText(res.getString("DExportPrivateKeyType.jrbOpenSsl.tooltip"));
-        if (keyPairType == KeyPairType.EDDSA || keyPairType == KeyPairType.ED25519 ||
-            keyPairType == KeyPairType.ED448) {
-            jrbOpenSsl.setEnabled(false);
-        }
+        jrbOpenSsl.setEnabled(OpenSslPvkUtil.isOpenSSLFormatSupported(privateKey));
 
         jrbJwk = new JRadioButton(res.getString("DExportPrivateKeyType.jrbJwk.text"));
         PlatformUtil.setMnemonic(jrbJwk, res.getString("DExportPrivateKeyType.jrbJwk.mnemonic").charAt(0));

--- a/kse/src/main/java/org/kse/gui/preferences/data/KeyGenerationSettings.java
+++ b/kse/src/main/java/org/kse/gui/preferences/data/KeyGenerationSettings.java
@@ -33,6 +33,7 @@ public class KeyGenerationSettings {
     private int keyPairSizeDSA = 1024;
     private String ecCurveSet = "";
     private String ecCurveName = "";
+    private KeyPairType mlDSAKeyPairType = KeyPairType.MLDSA44;
 
     private SecretKeyType secretKeyType = SecretKeyType.AES;
     private int secretKeySize = 128;
@@ -92,5 +93,15 @@ public class KeyGenerationSettings {
 
     public void setSecretKeySize(int secretKeySize) {
         this.secretKeySize = secretKeySize;
+    }
+
+    public KeyPairType getMLDSAKeyPairType() {
+        return mlDSAKeyPairType;
+    }
+
+    public void setMLDSAKeyPairType(KeyPairType keyPairType) {
+        if (KeyPairType.isMlDSA(keyPairType)) {
+            mlDSAKeyPairType = keyPairType;
+        }
     }
 }

--- a/kse/src/main/resources/org/kse/crypto/keypair/resources.properties
+++ b/kse/src/main/resources/org/kse/crypto/keypair/resources.properties
@@ -1,5 +1,6 @@
 
 NoGenerateKeypair.exception.message=Could not generate ''{0}'' key pair.
+NoGenerateKeypair.exception.NotMlDSA.message=Not ML-DSA key pair
 NoPublicKeysize.exception.message=Could not get the public key's size.
 NoPrivateKeysize.exception.message=Could not get the private key's size.
 NoCheckCompriseValidKeypair.exception.message=Could not check that the private and public keys comprise a key pair.

--- a/kse/src/main/resources/org/kse/crypto/signing/resources.properties
+++ b/kse/src/main/resources/org/kse/crypto/signing/resources.properties
@@ -30,6 +30,10 @@ SignatureType.Sha256WithEcDsa=SHA-256 with ECDSA
 SignatureType.Sha384WithEcDsa=SHA-384 with ECDSA
 SignatureType.Sha512WithEcDsa=SHA-512 with ECDSA
 
+SignatureType.MlDsa44=ml-dsa-44
+SignatureType.MlDsa65=ml-dsa-65
+SignatureType.MlDsa87=ml-dsa-87
+
 SignatureType.Sha1WithRsaAndMGF1=SHA-1 with RSA and MGF1
 SignatureType.Sha224WithRsaAndMGF1=SHA-224 with RSA and MGF1
 SignatureType.Sha256WithRsaAndMGF1=SHA-256 with RSA and MGF1

--- a/kse/src/main/resources/org/kse/crypto/signing/resources.properties
+++ b/kse/src/main/resources/org/kse/crypto/signing/resources.properties
@@ -30,9 +30,9 @@ SignatureType.Sha256WithEcDsa=SHA-256 with ECDSA
 SignatureType.Sha384WithEcDsa=SHA-384 with ECDSA
 SignatureType.Sha512WithEcDsa=SHA-512 with ECDSA
 
-SignatureType.MlDsa44=ml-dsa-44
-SignatureType.MlDsa65=ml-dsa-65
-SignatureType.MlDsa87=ml-dsa-87
+SignatureType.MlDsa44=ML-DSA-44
+SignatureType.MlDsa65=ML-DSA-65
+SignatureType.MlDsa87=ML-DSA-87
 
 SignatureType.Sha1WithRsaAndMGF1=SHA-1 with RSA and MGF1
 SignatureType.Sha224WithRsaAndMGF1=SHA-224 with RSA and MGF1

--- a/kse/src/main/resources/org/kse/gui/actions/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/actions/resources.properties
@@ -29,6 +29,7 @@ ChangeTypeAction.ChangeKeyStoreType.Title             = Change KeyStore Type
 ChangeTypeAction.ChangeKeyStoreTypeSuccessful.message = Change KeyStore Type Successful.
 ChangeTypeAction.History.text                         = Change Type to {0}
 ChangeTypeAction.WarnNoChangeKey.message              = The KeyStore contains at least one Key entry.\nThese entries will be lost in the type change.\nDo you want to continue?
+ChangeTypeAction.WarnNoMLDSA.message                  = The KeyStore contains at least one MLDSA KeyPair entry.\nThe new KeyStore type does not support MLDSA keys, \nso these entries will be lost in the type change.\nDo you want to continue?
 ChangeTypeAction.WarnNoECC.message                    = The KeyStore contains at least one EC KeyPair entry.\nThe new KeyStore type does not support EC keys, \nso these entries will be lost in the type change.\nDo you want to continue?
 ChangeTypeAction.statusbar                            = Change the active KeyStore''s type to {0}
 

--- a/kse/src/main/resources/org/kse/gui/dialogs/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/dialogs/resources.properties
@@ -114,6 +114,12 @@ DGenerateKeyPair.jrbRSA.text                        = RSA
 DGenerateKeyPair.jrbRSA.tooltip                     = RSA (Rivest, Shamir, Adleman) key pair
 DGenerateKeyPair.jsKeySize.tooltip                  = Key size in bits
 
+MLDSAKeySelector.jRadioButton.mnemonic              = M
+MLDSAKeySelector.jRadioButton.text                  = ML-DSA
+MLDSAKeySelector.jRadioButton.tooltip               = Select an ML-DSA (Module-Lattice Digital Signature Algorithm) key pair
+MLDSAKeySelector.jLabelKeyType.tooltip              = Parameter Set:
+MLDSAKeySelector.jComboBoxKeyType.tooltip           = Choose the ML-DSA parameter set (44, 65, or 87) that determines the security level
+
 DGenerateKeyPairCert.CritSANReq.message             = If the subject DN is empty, the certificate must include a subjectAltName extension that is marked as critical.
 DGenerateKeyPairCert.NameValueReq.message           = A value is required for Name.
 DGenerateKeyPairCert.SerialNumberNonZero.message    = Serial Number must be greater than zero.
@@ -347,6 +353,16 @@ DViewAsymmetricKeyFields.jltFields.PubRsaModulus.text          = Modulus
 DViewAsymmetricKeyFields.jltFields.PubRsaPublicExponent.text   = Public Exponent
 DViewAsymmetricKeyFields.jltFields.tooltip                     = Displays key's fields
 DViewAsymmetricKeyFields.jtaFieldValue.tooltip                 = Displays selected key field's value
+DViewAsymmetricKeyFields.jltFields.PrivateSeed.text            = Seed (32 bytes)
+DViewAsymmetricKeyFields.jltFields.PrivateExpanded.text        = Expanded Secret Key
+DViewAsymmetricKeyFields.jltFields.PublicKey.text              = Public Key
+DViewAsymmetricKeyFields.jltFields.PrivMldsaRho.rho.text       = Rho
+DViewAsymmetricKeyFields.jltFields.PrivMldsaS1.text            = S1
+DViewAsymmetricKeyFields.jltFields.PrivMldsaS2.text            = S2
+DViewAsymmetricKeyFields.jltFields.PrivMldsaT0.text            = T0
+DViewAsymmetricKeyFields.jltFields.PubMldsaT1.text             = T1
+DViewAsymmetricKeyFields.jltFields.PubMldsaTr.text             = Tr
+
 
 DViewCertificate.Extensions.Title                   = Certificate Extensions
 DViewCertificate.Issuer.Title                       = Issuer

--- a/kse/src/test/java/org/kse/crypto/KeyTestsBase.java
+++ b/kse/src/test/java/org/kse/crypto/KeyTestsBase.java
@@ -31,6 +31,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.util.Arrays;
 import java.util.List;
 
+import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
 import org.junit.jupiter.api.BeforeAll;
 import org.kse.KSE;
 import org.kse.crypto.keypair.KeyPairType;
@@ -48,9 +49,23 @@ public abstract class KeyTestsBase extends CryptoTestsBase {
     protected static DSAPublicKey dsaPublicKey;
     protected static ECPrivateKey ecPrivateKey;
     protected static ECPublicKey ecPublicKey;
+    protected static PublicKey mldsaPublicKey;
+    /**
+     * MLDSA private keys come with different types of encoding
+     * and each should be handled by KSE
+     * <p>
+     * {@link org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey#getPrivateKey}
+     * </p>
+     */
+    protected static PrivateKey mldsaPrivateKeySeedOnly;
+    protected static PrivateKey mldsaPrivateKeyExpandedOnly;
+    protected static PrivateKey mldsaPrivateKeySeedAndExpanded;
+
 
     public static List<PrivateKey> privateKeys() {
-        return Arrays.asList(rsaPrivateKey, dsaPrivateKey, ecPrivateKey);
+        return Arrays.asList(rsaPrivateKey, dsaPrivateKey, ecPrivateKey,
+                mldsaPrivateKeySeedAndExpanded, mldsaPrivateKeySeedOnly,
+                mldsaPrivateKeyExpandedOnly);
     }
 
     public static List<PublicKey> publicKeys() {
@@ -77,6 +92,16 @@ public abstract class KeyTestsBase extends CryptoTestsBase {
             ecPrivateKey = (ECPrivateKey) ecKeyPair.getPrivate();
             ecPublicKey = (ECPublicKey) ecKeyPair.getPublic();
         }
+
+        if (mldsaPublicKey == null) {
+            KeyPair mldsaKeyPair = KeyPairUtil.generateMLDSAKeyPair(KeyPairType.MLDSA44, KSE.BC);
+            mldsaPublicKey = mldsaKeyPair.getPublic();
+            MLDSAPrivateKey privateKey = (MLDSAPrivateKey) mldsaKeyPair.getPrivate();
+            mldsaPrivateKeySeedAndExpanded = privateKey;
+            mldsaPrivateKeySeedOnly = privateKey.getPrivateKey(true);
+            mldsaPrivateKeyExpandedOnly = privateKey.getPrivateKey(false);
+        }
+
     }
 
 }


### PR DESCRIPTION
* The following work is based on version 11 of the RFC Draft https://datatracker.ietf.org/doc/draft-ietf-lamps-dilithium-certificates/11/

* Upgraded Bouncy Castle to version 1.81 to enable PKCS#8 encoding that carries both the seed and the expanded key (older BC versions exports only the seed)

* New features:
    * Generate ML-DSA key pairs and X.509 certificates
    * Create ML-DSA-signed CRLs, CSRs and files
    * Import / export ML-DSA key pairs in PKCS#12 and PEM
    * Import / export ML-DSA private keys in PKCS#8
    * Import / export ML-DSA public keys in OpenSSL “PUBLIC KEY” PEM
    * Display detailed ML-DSA fields in the key-viewer dialog

* Known limitations:
    * JAR signing works but resulting signatures are not yet recognised by standard tools or are bogus
    * Pre-hashed signatures are not supported
    * Private-key export always includes both seed and expanded key; no UI to choose one or the other.
    * UI strings are currently available in English only