### PR TITLE
Convert to using EdDSA interfaces rather than classes.

### DIFF
--- a/kse/src/main/java/org/kse/crypto/jwk/JwkExporter.java
+++ b/kse/src/main/java/org/kse/crypto/jwk/JwkExporter.java
@@ -23,8 +23,8 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
 import java.util.Map;
 
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+import org.bouncycastle.jcajce.interfaces.EdDSAPrivateKey;
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.keypair.KeyPairUtil;
 
@@ -85,11 +85,11 @@ public interface JwkExporter {
                         "Ed448", Curve.Ed448
                 );
 
-        protected Curve getCurve(BCEdDSAPublicKey bcEdDSAPublicKey) {
+        protected Curve getCurve(EdDSAPublicKey bcEdDSAPublicKey) {
             return supportedCurvesMap.get(bcEdDSAPublicKey.getAlgorithm());
         }
 
-        protected Curve getCurve(BCEdDSAPrivateKey bcEdDSAPrivateKey) {
+        protected Curve getCurve(EdDSAPrivateKey bcEdDSAPrivateKey) {
             return supportedCurvesMap.get(bcEdDSAPrivateKey.getAlgorithm());
         }
     }

--- a/kse/src/main/java/org/kse/crypto/privatekey/JwkPrivateKeyExporter.java
+++ b/kse/src/main/java/org/kse/crypto/privatekey/JwkPrivateKeyExporter.java
@@ -31,8 +31,8 @@ import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jcajce.interfaces.EdDSAPrivateKey;
 import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
 import org.kse.KSE;
 import org.kse.crypto.jwk.JwkExporter;
 import org.kse.crypto.jwk.JwkExporterException;
@@ -53,7 +53,7 @@ public class JwkPrivateKeyExporter {
             this.jwkExporter = new RSAPrivateKeyExporter(privateKey);
         } else if (privateKey instanceof ECPrivateKey) {
             this.jwkExporter = new ECPrivateKeyExporter(privateKey);
-        } else if (privateKey instanceof BCEdDSAPrivateKey) {
+        } else if (privateKey instanceof EdDSAPrivateKey) {
             this.jwkExporter = new EdDSAPrivateKeyExporter(privateKey);
         } else {
             // JDK 15 has native support for EdDSA keys
@@ -92,10 +92,10 @@ public class JwkPrivateKeyExporter {
     }
 
     private static class EdDSAPrivateKeyExporter extends JwkExporter.EdDSAKeyExporter {
-        private final BCEdDSAPrivateKey privateKey;
+        private final EdDSAPrivateKey privateKey;
 
         private EdDSAPrivateKeyExporter(PrivateKey privateKey) {
-            this.privateKey = (BCEdDSAPrivateKey) privateKey;
+            this.privateKey = (EdDSAPrivateKey) privateKey;
         }
 
         @Override

--- a/kse/src/main/java/org/kse/crypto/publickey/JwkPublicKeyExporter.java
+++ b/kse/src/main/java/org/kse/crypto/publickey/JwkPublicKeyExporter.java
@@ -25,7 +25,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.kse.crypto.KeyInfo;
 import org.kse.crypto.jwk.JwkExporter;
 import org.kse.crypto.jwk.JwkExporterException;
@@ -45,7 +45,7 @@ public class JwkPublicKeyExporter {
         this.alias = alias;
         if (publicKey instanceof ECPublicKey) {
             this.jwkExporter = new JwkPublicKeyExporter.ECPublicKeyExporter(publicKey);
-        } else if (publicKey instanceof BCEdDSAPublicKey) {
+        } else if (publicKey instanceof EdDSAPublicKey) {
             this.jwkExporter = new JwkPublicKeyExporter.EdDSAPublicKeyExporter(publicKey);
         } else if (publicKey instanceof RSAPublicKey) {
             this.jwkExporter = new JwkPublicKeyExporter.RSAPublicKeyExporter(publicKey);
@@ -82,10 +82,10 @@ public class JwkPublicKeyExporter {
     }
 
     private static class EdDSAPublicKeyExporter extends JwkExporter.EdDSAKeyExporter {
-        private final BCEdDSAPublicKey bcEdDSAPublicKey;
+        private final EdDSAPublicKey bcEdDSAPublicKey;
 
         EdDSAPublicKeyExporter(PublicKey publicKey) {
-            this.bcEdDSAPublicKey = (BCEdDSAPublicKey) publicKey;
+            this.bcEdDSAPublicKey = (EdDSAPublicKey) publicKey;
         }
 
         @Override

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
@@ -63,8 +63,6 @@ import org.bouncycastle.jcajce.interfaces.EdDSAPrivateKey;
 import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.bouncycastle.jcajce.interfaces.MLDSAPrivateKey;
 import org.bouncycastle.jcajce.interfaces.MLDSAPublicKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPrivateKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 import org.bouncycastle.jcajce.provider.asymmetric.mldsa.BCMLDSAPrivateKey;
 import org.bouncycastle.pqc.crypto.mldsa.MLDSAParameters;
 import org.bouncycastle.pqc.crypto.mldsa.MLDSAPrivateKeyParameters;
@@ -74,9 +72,9 @@ import org.kse.KSE;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.components.JEscDialog;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.components.JEscDialog;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.io.HexUtil;
 
@@ -141,11 +139,11 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
     private static String getEdAlg(Key key) {
         // Ed25519 or Ed448?
         String edAlg;
-        if (key instanceof BCEdDSAPublicKey) {
-            BCEdDSAPublicKey bcEdDSAPublicKey = (BCEdDSAPublicKey) key;
+        if (key instanceof EdDSAPublicKey) {
+            EdDSAPublicKey bcEdDSAPublicKey = (EdDSAPublicKey) key;
             edAlg = bcEdDSAPublicKey.getAlgorithm(); // Ed25519 or Ed448
         } else {
-            BCEdDSAPrivateKey bcEdDSAPrivateKey = (BCEdDSAPrivateKey) key;
+            EdDSAPrivateKey bcEdDSAPrivateKey = (EdDSAPrivateKey) key;
             edAlg = bcEdDSAPrivateKey.getAlgorithm();
         }
         return edAlg;

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewJwt.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewJwt.java
@@ -49,7 +49,7 @@ import javax.swing.JTextArea;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.ecc.EdDSACurves;
 import org.kse.crypto.filetype.CryptoFileType;
@@ -302,7 +302,7 @@ public class DViewJwt extends JEscDialog {
             } else if (publicKey instanceof RSAPublicKey) {
                 verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
             // Works for Java 15+ since OpenSslPubUtil uses the BC provider for loading the key
-            } else if (publicKey instanceof BCEdDSAPublicKey) {
+            } else if (publicKey instanceof EdDSAPublicKey) {
                 // Prevent exceptions in case an Ed448 key is used. There's no JWSVerifier for Ed448 keys.
                 if (EdDSACurves.ED448.jce().equals(publicKey.getAlgorithm()))
                 {
@@ -311,7 +311,7 @@ public class DViewJwt extends JEscDialog {
                     return;
                 }
                 OctetKeyPair okp = new OctetKeyPair.Builder(Curve.Ed25519,
-                        Base64URL.encode(((BCEdDSAPublicKey) publicKey).getPointEncoding())).build();
+                        Base64URL.encode(((EdDSAPublicKey) publicKey).getPointEncoding())).build();
                 verifier = new Ed25519Verifier(okp);
             } else {
                 JOptionPane.showMessageDialog(this, res.getString("DViewJwt.InvalidPublicKey.message"),

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPublicKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPublicKey.java
@@ -46,17 +46,17 @@ import javax.swing.JTextField;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.bouncycastle.jcajce.interfaces.MLDSAPublicKey;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
 import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.crypto.publickey.OpenSslPubUtil;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.components.JEscDialog;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.components.JEscDialog;
 import org.kse.gui.crypto.JPublicKeyFingerprint;
 import org.kse.gui.error.DError;
 import org.kse.gui.preferences.PreferencesManager;
@@ -273,7 +273,7 @@ public class DViewPublicKey extends JEscDialog {
         jcfFingerprint.setFingerprintAlg(preferences.getPublicKeyFingerprintAlgorithm());
 
         jbFields.setEnabled((publicKey instanceof RSAPublicKey) || (publicKey instanceof DSAPublicKey)
-                || (publicKey instanceof ECPublicKey) || (publicKey instanceof BCEdDSAPublicKey)
+                || (publicKey instanceof ECPublicKey) || (publicKey instanceof EdDSAPublicKey)
                 || publicKey instanceof MLDSAPublicKey);
     }
 

--- a/kse/src/test/java/org/kse/crypto/publickey/JwkPublicKeyExporterTest.java
+++ b/kse/src/test/java/org/kse/crypto/publickey/JwkPublicKeyExporterTest.java
@@ -20,7 +20,8 @@
 package org.kse.crypto.publickey;
 
 import com.nimbusds.jose.JOSEException;
-import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey;
+
+import org.bouncycastle.jcajce.interfaces.EdDSAPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECNamedCurveSpec;
 import org.bouncycastle.util.encoders.Hex;
@@ -171,7 +172,7 @@ public class JwkPublicKeyExporterTest {
             X509EncodedKeySpec keySpec = new X509EncodedKeySpec(spkiEncoded);
             KeyFactory keyFactory = KeyFactory.getInstance("Ed25519", "BC");
 
-            BCEdDSAPublicKey publicKey = (BCEdDSAPublicKey) keyFactory.generatePublic(keySpec);
+            EdDSAPublicKey publicKey = (EdDSAPublicKey) keyFactory.generatePublic(keySpec);
             JwkPublicKeyExporter exporter = JwkPublicKeyExporter.from(publicKey, null);
             String exportedKey = new String(exporter.get());
 
@@ -191,7 +192,7 @@ public class JwkPublicKeyExporterTest {
             X509EncodedKeySpec keySpec = new X509EncodedKeySpec(spkiEncoded);
             KeyFactory keyFactory = KeyFactory.getInstance("Ed448", "BC");
 
-            BCEdDSAPublicKey publicKey = (BCEdDSAPublicKey) keyFactory.generatePublic(keySpec);
+            EdDSAPublicKey publicKey = (EdDSAPublicKey) keyFactory.generatePublic(keySpec);
             JwkPublicKeyExporter exporter = JwkPublicKeyExporter.from(publicKey, "testAlias");
             String exportedKey = new String(exporter.get());
 
@@ -209,7 +210,7 @@ public class JwkPublicKeyExporterTest {
     @Test
     void handlesAttemptToExportUnsupportedEdDSAKeyWithGrace()  {
         assertThrows(JwkExporterException.class, () -> {
-            BCEdDSAPublicKey publicKeyMock = mock(BCEdDSAPublicKey.class);
+            EdDSAPublicKey publicKeyMock = mock(EdDSAPublicKey.class);
             when(publicKeyMock.getAlgorithm()).thenReturn("UnsupportedCurve");
             JwkPublicKeyExporter jwkPublicKeyExporter = JwkPublicKeyExporter.from(publicKeyMock, null);
             jwkPublicKeyExporter.get();


### PR DESCRIPTION
This is a somewhat unnecessary PR, but I noticed that AnassBousseaden had switched to using the EdDSAPublicKey and EdDSAPrivateKey interfaces instead of the BCEdDSAPublicKey and BCEdDSAPrivateKey classes during some refactoring. I liked it so I took it and applied it to the rest of the code base.