### PR TITLE
Add `CertificatePolicies` OIDs of 'CA/Browser Forum'

### DIFF
--- a/kse/src/main/java/org/kse/utilities/oid/ObjectIdUtil.java
+++ b/kse/src/main/java/org/kse/utilities/oid/ObjectIdUtil.java
@@ -1995,6 +1995,13 @@ public class ObjectIdUtil {
         oidToNameMapping.put("2.23.42.9.7", "BankGate");
         oidToNameMapping.put("2.23.42.9.8", "GTE");
         oidToNameMapping.put("2.23.42.9.9", "CompuSource");
+        oidToNameMapping.put("2.23.140", "CaBrowserForum");
+        oidToNameMapping.put("2.23.140.1", "CertificatePolicies");
+        oidToNameMapping.put("2.23.140.1.1", "EvGuidelines");
+        oidToNameMapping.put("2.23.140.1.2", "BaselineRequirements");
+        oidToNameMapping.put("2.23.140.1.2.1", "DomainValidated");
+        oidToNameMapping.put("2.23.140.1.2.2", "OrganizationValidated");
+        oidToNameMapping.put("2.23.140.1.2.3", "IndividualValidated");
         oidToNameMapping.put("2.5.29.1", "AuthorityKeyIdentifier");
         oidToNameMapping.put("2.5.29.10", "BasicConstraints");
         oidToNameMapping.put("2.5.29.11", "NameConstraints");


### PR DESCRIPTION
Hello KSE Team, @kaikramer, and all,

Here is a PR in order to:
- add `CertificatePolicies` OIDs of 'CA/Browser Forum'
  _And especially:_
  - `domain-validated(1) — 2.23.140.1.2.1` (Certificate issued in compliance with the TLS Baseline Requirements – No entity identity asserted)
  - `organization-validated(2) — 2.23.140.1.2.2` (Certificate issued in compliance with the TLS Baseline Requirements – Organization identity asserted)
  - `individual-validated(3) — 2.23.140.1.2.3` (Certificate issued in compliance with the TLS Baseline Requirements – Individual identity asserted)

_Reason_:
Because those OIDs are widely used in the Certificate Policies (`2.5.29.32`-`CP`) fields.

_Ref._:
- https://cabforum.org/resources/object-registry/
- https://github.com/cabforum/cabforum.org/blob/main/content/resources/object-registry/index.md
- https://oid-base.com/get/2.23.140.1.2

Regards,
Th.