### PR TITLE
Don't check key entries for sign menu enablement. Fixes #581

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -2457,12 +2457,6 @@ public final class KseFrame implements StatusBar {
                         unlockKeyAction.setEnabled(locked);
                     }
 
-                    signMidletAction.setEnabled(signMidletAction.isKeySupported(getSelectedEntryAlias()));
-                    jmiKeyPairSignMidlet.setToolTipText(signMidletAction.getToolTip());
-
-                    signJwtAction.setEnabled(signJwtAction.isKeySupported(getSelectedEntryAlias()));
-                    jmiKeyPairSignJwt.setToolTipText(signJwtAction.getToolTip());
-
                     jpmKey.show(jtKeyStore, x, y);
                 }
             }


### PR DESCRIPTION
Fix #581 by limiting MIDlet and JWT signing availability to just the key pair entries.