### PR TITLE
fix duplicate shortcut

### DIFF
--- a/kse/src/main/java/org/kse/gui/actions/ExamineSslAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ExamineSslAction.java
@@ -48,7 +48,7 @@ public class ExamineSslAction extends KeyStoreExplorerAction {
     public ExamineSslAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('S',
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('T',
                                                          Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx() +
                                                          InputEvent.ALT_DOWN_MASK));
         putValue(LONG_DESCRIPTION, res.getString("ExamineSslAction.statusbar"));


### PR DESCRIPTION
Hello KSC Team, @kaikramer 

To continue:
- 8e67d6e

Here is a PR in order to
- fix duplicate shortcut `Ctrl+Alt+S`
_(discovered here kaikramer/kaikramer.github.io#10)_
- change `Examine TLS` shortcut from `Ctrl+Alt+S` to `Ctrl+Alt+T`

See also ref. about TLS/SSL:
- #512

Regards,
Th.