### PR TITLE
update GHA workflows: fix `build_test` and create manual `compile`

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -33,5 +33,5 @@ jobs:
       with:
         name: 'artifacts'
         path: |
-          build/libs/kse.jar
+          kse/build/libs/kse.jar
           kse/build/distributions/kse-*.zip

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,31 @@
+name: Compile KSE (manual)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: 'Set up JDK'
+      uses: actions/setup-java@v2
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: 'Grant execute permission for gradlew'
+      run: chmod +x gradlew
+      working-directory: kse
+
+    - name: 'Java Compile with Gradle'
+      run: ./gradlew jar
+      working-directory: kse
+
+    - name: 'Publish Compile'
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'libs-kse'
+        path: kse/build/libs/kse.jar


### PR DESCRIPTION
Hello KSE Team, @kaikramer 

To continue:
- 4dd6b05
- and discussion: https://github.com/kaikramer/keystore-explorer/issues/360#issuecomment-1484209223

Here is a PR in order to:
- [x] fix `build_test` GHA with correct artifact path
- [x] create `compile` GHA to compile KSE JAR manually 

Regards,
Th.
