### PR TITLE
[GUI] Attempt to improve the shortcut displaying on the different menus

### DIFF
--- a/kse/src/main/java/org/kse/gui/actions/DeleteKeyAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/DeleteKeyAction.java
@@ -20,11 +20,13 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
@@ -32,6 +34,7 @@ import org.kse.gui.passwordmanager.PasswordManager;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
+import org.kse.utilities.os.OperatingSystem;
 
 /**
  * Action to delete the selected key.
@@ -47,6 +50,7 @@ public class DeleteKeyAction extends KeyStoreExplorerAction implements HistoryAc
     public DeleteKeyAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke((OperatingSystem.isMacOs()) ? KeyEvent.VK_BACK_SPACE : KeyEvent.VK_DELETE, 0));
         putValue(LONG_DESCRIPTION, res.getString("DeleteKeyAction.statusbar"));
         putValue(NAME, res.getString("DeleteKeyAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("DeleteKeyAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/DeleteKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/DeleteKeyPairAction.java
@@ -20,17 +20,20 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
+import org.kse.utilities.os.OperatingSystem;
 
 /**
  * Action to delete the selected key pair.
@@ -46,6 +49,7 @@ public class DeleteKeyPairAction extends KeyStoreExplorerAction implements Histo
     public DeleteKeyPairAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke((OperatingSystem.isMacOs()) ? KeyEvent.VK_BACK_SPACE : KeyEvent.VK_DELETE, 0));
         putValue(LONG_DESCRIPTION, res.getString("DeleteKeyPairAction.statusbar"));
         putValue(NAME, res.getString("DeleteKeyPairAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("DeleteKeyPairAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/DeleteMultipleEntriesAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/DeleteMultipleEntriesAction.java
@@ -20,16 +20,19 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
+import org.kse.utilities.os.OperatingSystem;
 
 /**
  * Action to delete multiple selected entries.
@@ -45,6 +48,7 @@ public class DeleteMultipleEntriesAction extends KeyStoreExplorerAction implemen
     public DeleteMultipleEntriesAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke((OperatingSystem.isMacOs()) ? KeyEvent.VK_BACK_SPACE : KeyEvent.VK_DELETE, 0));
         putValue(LONG_DESCRIPTION, res.getString("DeleteMultipleEntriesAction.statusbar"));
         putValue(NAME, res.getString("DeleteMultipleEntriesAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("DeleteMultipleEntriesAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/DeleteTrustedCertificateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/DeleteTrustedCertificateAction.java
@@ -20,17 +20,20 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
+import org.kse.utilities.os.OperatingSystem;
 
 /**
  * Action to delete the selected trusted certificate.
@@ -46,6 +49,7 @@ public class DeleteTrustedCertificateAction extends KeyStoreExplorerAction imple
     public DeleteTrustedCertificateAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke((OperatingSystem.isMacOs()) ? KeyEvent.VK_BACK_SPACE : KeyEvent.VK_DELETE, 0));
         putValue(LONG_DESCRIPTION, res.getString("DeleteTrustedCertificateAction.statusbar"));
         putValue(NAME, res.getString("DeleteTrustedCertificateAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("DeleteTrustedCertificateAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyDetailsAction.java
@@ -20,6 +20,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -30,6 +31,7 @@ import java.util.Optional;
 
 import javax.crypto.SecretKey;
 import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
 
 import org.kse.crypto.CryptoException;
 import org.kse.gui.passwordmanager.Password;
@@ -55,6 +57,7 @@ public class KeyDetailsAction extends KeyStoreExplorerAction {
     public KeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
         putValue(LONG_DESCRIPTION, res.getString("KeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairCertificateChainDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairCertificateChainDetailsAction.java
@@ -20,11 +20,13 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
 
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
@@ -47,6 +49,7 @@ public class KeyPairCertificateChainDetailsAction extends KeyStoreExplorerAction
     public KeyPairCertificateChainDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
         putValue(LONG_DESCRIPTION, res.getString("KeyPairCertificateChainDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyPairCertificateChainDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyPairCertificateChainDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
@@ -20,6 +20,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.text.MessageFormat;
@@ -49,7 +50,7 @@ public class KeyPairPrivateKeyDetailsAction extends KeyStoreExplorerAction {
     public KeyPairPrivateKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed -"));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_MINUS, 0));
         putValue(LONG_DESCRIPTION, res.getString("KeyPairPrivateKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyPairPrivateKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyPairPrivateKeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairPrivateKeyDetailsAction.java
@@ -20,7 +20,6 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
-import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.text.MessageFormat;
@@ -50,7 +49,7 @@ public class KeyPairPrivateKeyDetailsAction extends KeyStoreExplorerAction {
     public KeyPairPrivateKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_SUBTRACT, 0));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed -"));
         putValue(LONG_DESCRIPTION, res.getString("KeyPairPrivateKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyPairPrivateKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyPairPrivateKeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairPublicKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairPublicKeyDetailsAction.java
@@ -20,7 +20,6 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
-import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.text.MessageFormat;
@@ -49,7 +48,7 @@ public class KeyPairPublicKeyDetailsAction extends KeyStoreExplorerAction {
     public KeyPairPublicKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed +"));
         putValue(LONG_DESCRIPTION, res.getString("KeyPairPublicKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyPairPublicKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyPairPublicKeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/KeyPairPublicKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/KeyPairPublicKeyDetailsAction.java
@@ -20,6 +20,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.text.MessageFormat;
@@ -48,7 +49,7 @@ public class KeyPairPublicKeyDetailsAction extends KeyStoreExplorerAction {
     public KeyPairPublicKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed +"));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, 0));
         putValue(LONG_DESCRIPTION, res.getString("KeyPairPublicKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("KeyPairPublicKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("KeyPairPublicKeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/RenameKeyAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameKeyAction.java
@@ -20,12 +20,14 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.Key;
 import java.security.KeyStore;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.passwordmanager.Password;
 import org.kse.gui.KseFrame;
@@ -49,6 +51,7 @@ public class RenameKeyAction extends KeyStoreExplorerAction implements HistoryAc
     public RenameKeyAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0));
         putValue(LONG_DESCRIPTION, res.getString("RenameKeyAction.statusbar"));
         putValue(NAME, res.getString("RenameKeyAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("RenameKeyAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/RenameKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameKeyPairAction.java
@@ -20,6 +20,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.Key;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -27,6 +28,7 @@ import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.passwordmanager.Password;
 import org.kse.crypto.x509.X509CertUtil;
@@ -51,6 +53,7 @@ public class RenameKeyPairAction extends KeyStoreExplorerAction implements Histo
     public RenameKeyPairAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0));
         putValue(LONG_DESCRIPTION, res.getString("RenameKeyPairAction.statusbar"));
         putValue(NAME, res.getString("RenameKeyPairAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("RenameKeyPairAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/RenameTrustedCertificateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameTrustedCertificateAction.java
@@ -20,12 +20,14 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 
 import org.kse.gui.KseFrame;
 import org.kse.gui.dialogs.DGetAlias;
@@ -48,6 +50,7 @@ public class RenameTrustedCertificateAction extends KeyStoreExplorerAction imple
     public RenameTrustedCertificateAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_F2, 0));
         putValue(LONG_DESCRIPTION, res.getString("RenameTrustedCertificateAction.statusbar"));
         putValue(NAME, res.getString("RenameTrustedCertificateAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("RenameTrustedCertificateAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/TrustedCertificateDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/TrustedCertificateDetailsAction.java
@@ -20,11 +20,13 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
 
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
@@ -46,6 +48,7 @@ public class TrustedCertificateDetailsAction extends KeyStoreExplorerAction {
     public TrustedCertificateDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
         putValue(LONG_DESCRIPTION, res.getString("TrustedCertificateDetailsAction.statusbar"));
         putValue(NAME, res.getString("TrustedCertificateDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("TrustedCertificateDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/TrustedCertificatePublicKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/TrustedCertificatePublicKeyDetailsAction.java
@@ -20,7 +20,6 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
-import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.text.MessageFormat;
@@ -49,7 +48,7 @@ public class TrustedCertificatePublicKeyDetailsAction extends KeyStoreExplorerAc
     public TrustedCertificatePublicKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ADD, 0));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed +"));
         putValue(LONG_DESCRIPTION, res.getString("TrustedCertificatePublicKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("TrustedCertificatePublicKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("TrustedCertificatePublicKeyDetailsAction.tooltip"));

--- a/kse/src/main/java/org/kse/gui/actions/TrustedCertificatePublicKeyDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/TrustedCertificatePublicKeyDetailsAction.java
@@ -20,6 +20,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.PublicKey;
 import java.text.MessageFormat;
@@ -48,7 +49,7 @@ public class TrustedCertificatePublicKeyDetailsAction extends KeyStoreExplorerAc
     public TrustedCertificatePublicKeyDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke("typed +"));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_PLUS, 0));
         putValue(LONG_DESCRIPTION, res.getString("TrustedCertificatePublicKeyDetailsAction.statusbar"));
         putValue(NAME, res.getString("TrustedCertificatePublicKeyDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("TrustedCertificatePublicKeyDetailsAction.tooltip"));


### PR DESCRIPTION
Hello KSE Team, @kaikramer,

To resolve:

- #593

Here is first attempt to:
- improve the shortcut displaying on the different menus for:
  - `Delete`
  - `Rename` with `F2`
  - `View Details` with `=`/`+`/`-`

---

**Open question**
- Should we create shortcuts for the following actions _(which have still nothing today)_:
  - `Unlock`
  - `Set Password`
  - or all the `Exports`...

Regards,
Th.