### PR TITLE
[GUI][Rename Shorcut] Suppress unnecessary code (or old dead code) about Rename Action shortcut

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -558,7 +558,6 @@ public final class KseFrame implements StatusBar {
     private static final String CUT_KEY = "CUT_KEY";
     private static final String COPY_KEY = "COPY_KEY";
     private static final String PASTE_KEY = "PASTE_KEY";
-    private static final String RENAME_KEY = "RENAME_KEY";
     private static final String CONTEXT_MENU_KEY = "CONTEXT_MENU_KEY";
 
     public KseFrame() {
@@ -1652,9 +1651,6 @@ public final class KseFrame implements StatusBar {
 
         jtKeyStore.getInputMap().put((KeyStroke) pasteAction.getValue(Action.ACCELERATOR_KEY), PASTE_KEY);
         jtKeyStore.getActionMap().put(PASTE_KEY, pasteAction);
-
-        jtKeyStore.getInputMap().put((KeyStroke) renameKeyPairAction.getValue(Action.ACCELERATOR_KEY), RENAME_KEY);
-        jtKeyStore.getActionMap().put(RENAME_KEY, renameKeyPairAction);
 
         jtKeyStore.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_F10, InputEvent.SHIFT_DOWN_MASK, true), CONTEXT_MENU_KEY);
         jtKeyStore.getInputMap().put(KeyStroke.getKeyStroke(KeyEvent.VK_CONTEXT_MENU, 0, true), CONTEXT_MENU_KEY);


### PR DESCRIPTION
Hello KSE Team, @kaikramer 

To continue:
- #593

But with:
- #594

Creating or reactivating accelerator key for `rename` (`F2`) created some issues or NPE: waking up dead (or dormant) code, because there are several actions (`RenameKeyAction` / `RenameKeyPairAction` / `RenameTrustedCertificateAction`) and not just one (unlike `cut`/`copy`/`paste`)!

Then here is the suppression of all the corresponding dead code before my PR #594.

Historic _(first commits)_ of the lines:
- 502a961
- b9add75

[_Sorry: I prefer to do lots of small PRs..._]

Regards,
Th.
