### PR TITLE
[GUI][Shortcut] add `Enter` shortcut for `SelectedCertificatesChainDetailsAction`

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -559,6 +559,7 @@ public final class KseFrame implements StatusBar {
     private static final String COPY_KEY = "COPY_KEY";
     private static final String PASTE_KEY = "PASTE_KEY";
     private static final String CONTEXT_MENU_KEY = "CONTEXT_MENU_KEY";
+    private static final String ENTER_KEY = "ENTER_KEY";
 
     public KseFrame() {
         initComponents();
@@ -1665,17 +1666,21 @@ public final class KseFrame implements StatusBar {
 
         // open keystore entry details when user presses enter key
         KeyStroke enter = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
-        jtKeyStore.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(enter, "Enter");
-        jtKeyStore.getActionMap().put("Enter", new AbstractAction() {
+        jtKeyStore.getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT).put(enter, ENTER_KEY);
+        jtKeyStore.getActionMap().put(ENTER_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
 
             @Override
             public void actionPerformed(ActionEvent ae) {
                 try {
-                    int selectedRow = jtKeyStore.getSelectedRow();
-                    if (selectedRow != -1) {
-                        CursorUtil.setCursorBusy(frame);
+                    int selectedRowCount = jtKeyStore.getSelectedRowCount();
+                    CursorUtil.setCursorBusy(frame);
+                    if (selectedRowCount == 1) {
+                        int selectedRow = jtKeyStore.getSelectedRow();
                         showSelectedEntryDetails(jtKeyStore, selectedRow);
+                    }
+                    else if (selectedRowCount > 1) {
+                        selectedCertificatesChainDetailsAction.showCertificatesSelectedEntries();
                     }
                 } finally {
                     CursorUtil.setCursorFree(frame);

--- a/kse/src/main/java/org/kse/gui/actions/SelectedCertificatesChainDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/SelectedCertificatesChainDetailsAction.java
@@ -43,7 +43,7 @@ public class SelectedCertificatesChainDetailsAction extends KeyStoreExplorerActi
     }
 
     @Override
-   protected void doAction() {
+    protected void doAction() {
         showCertificatesSelectedEntries();
     }
 

--- a/kse/src/main/java/org/kse/gui/actions/SelectedCertificatesChainDetailsAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/SelectedCertificatesChainDetailsAction.java
@@ -1,6 +1,7 @@
 package org.kse.gui.actions;
 
 import java.awt.Toolkit;
+import java.awt.event.KeyEvent;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -10,6 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.swing.ImageIcon;
+import javax.swing.KeyStroke;
 
 import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.gui.KseFrame;
@@ -32,6 +34,7 @@ public class SelectedCertificatesChainDetailsAction extends KeyStoreExplorerActi
      */
     public SelectedCertificatesChainDetailsAction(KseFrame kseFrame) {
         super(kseFrame);
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0));
         putValue(LONG_DESCRIPTION, res.getString("SelectedCertificatesChainDetailsAction.statusbar"));
         putValue(NAME, res.getString("SelectedCertificatesChainDetailsAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("SelectedCertificatesChainDetailsAction.tooltip"));
@@ -40,7 +43,14 @@ public class SelectedCertificatesChainDetailsAction extends KeyStoreExplorerActi
     }
 
     @Override
-    protected void doAction() {
+   protected void doAction() {
+        showCertificatesSelectedEntries();
+    }
+
+    /**
+     * Show the certificates details of the multiple selected KeyStore entries.
+     */
+    public void showCertificatesSelectedEntries() {
         Set<X509Certificate> setCertificates = getCertificates();
         X509Certificate[] certs = setCertificates.toArray(new X509Certificate[0]);
         DViewCertificate dViewCertificate;

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
@@ -61,6 +61,7 @@ public class DListCertificatesKS extends JEscDialog {
     private static final long serialVersionUID = 1L;
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/sign/resources");
     private static final String CANCEL_KEY = "CANCEL_KEY";
+    private static final String ENTER_KEY = "ENTER_KEY";
 
     private KseFrame kseFrame;
 
@@ -127,8 +128,8 @@ public class DListCertificatesKS extends JEscDialog {
         KeyStroke enter = KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0);
         jListCertificates.getJtListCerts()
                          .getInputMap(JComponent.WHEN_ANCESTOR_OF_FOCUSED_COMPONENT)
-                         .put(enter, "Enter");
-        jListCertificates.getJtListCerts().getActionMap().put("Enter", new AbstractAction() {
+                         .put(enter, ENTER_KEY);
+        jListCertificates.getJtListCerts().getActionMap().put(ENTER_KEY, new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent ae) {
                 okPressed();


### PR DESCRIPTION
Hello KSE Team, @kaikramer and @jgrateron, and all,

To resolve:
- #593

And to continue:
- #594
- #595

And to add a **shortcut** for:
- #572
- #573 

Here is a PR in order to:
- add `Enter` shortcut  for `SelectedCertificatesChainDetailsAction`
- fix all `"Enter"` (change `"Enter"` by `ENTER_KEY`)
	
---

Then here is a use-case: When you open a keystore, we can now type:
- `Ctrl+A`
- `Enter`
- Then you show directly the `SelectedCertificatesChainDetails`

_[FYI @jgrateron]_

---

_Enjoy,_
Regards,
Th.