### PR TITLE
Request focus for active keystore table after updating the controls.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -91,7 +91,6 @@ import javax.swing.table.TableRowSorter;
 
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
-import org.kse.crypto.ecc.EdDSACurves;
 import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.gui.actions.AboutAction;
@@ -3039,6 +3038,8 @@ public final class KseFrame implements StatusBar {
 
         updateKeyStoreTabsText();
         updateApplicationTitle();
+
+        getActiveKeyStoreTable().requestFocusInWindow();
 
         frame.repaint();
     }


### PR DESCRIPTION
Request the focus for the active keystore table after the updating the controls to fix #577. 