### PR TITLE
Reorganize the multi-selection context menu. Adds unlock option.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -415,6 +415,7 @@ public final class KseFrame implements StatusBar {
     private JMenuItem jmiMultiEntrySelDelete;
     private JMenuItem jmiMultiEntryCompare;
     private JMenuItem jmiMultiEntryExport;
+    private JMenuItem jmiMultiEntryUnlock;
 
     //
     // Main display controls
@@ -2331,13 +2332,21 @@ public final class KseFrame implements StatusBar {
         new StatusBarChangeHandler(jmiMultiEntryExport,
                 (String) exportSelectedCertificatesAction.getValue(Action.LONG_DESCRIPTION), this);
 
+        jmiMultiEntryUnlock = new  JMenuItem(unlockKeyAction);
+        jmiMultiEntryUnlock.setToolTipText(null);
+        new StatusBarChangeHandler(jmiMultiEntryUnlock,
+                (String) unlockKeyAction.getValue(Action.LONG_DESCRIPTION), this);
+
         jpmMultiEntrySel = new JPopupMenu();
-        jpmMultiEntrySel.add(jmiMultiEntryDetails);
         jpmMultiEntrySel.add(jmiMultiEntrySelCut);
         jpmMultiEntrySel.add(jmiMultEntrySelCopy);
         jpmMultiEntrySel.add(jmiMultiEntrySelDelete);
-        jpmMultiEntrySel.add(jmiMultiEntryCompare);
+        jpmMultiEntrySel.addSeparator();
+        jpmMultiEntrySel.add(jmiMultiEntryDetails);
         jpmMultiEntrySel.add(jmiMultiEntryExport);
+        jpmMultiEntrySel.add(jmiMultiEntryCompare);
+        jpmMultiEntrySel.addSeparator();
+        jpmMultiEntrySel.add(jmiMultiEntryUnlock);
 
     }
 
@@ -2449,6 +2458,20 @@ public final class KseFrame implements StatusBar {
                     .resolveJce(getActiveKeyStoreHistory().getCurrentState().getKeyStore().getType());
 
             if (jtKeyStore.getSelectedRows().length > 1) {
+
+                boolean hasKeyEntry = false;
+                boolean hasCertEntry = false;
+                for (int r : jtKeyStore.getSelectedRows()) {
+                    hasKeyEntry |= KeyStoreTableModel.EntryType.KEY_PAIR.equals(jtKeyStore.getValueAt(r, 0))
+                            || KeyStoreTableModel.EntryType.KEY.equals(jtKeyStore.getValueAt(r, 0));
+                    hasCertEntry |= KeyStoreTableModel.EntryType.KEY_PAIR.equals(jtKeyStore.getValueAt(r, 0))
+                            || KeyStoreTableModel.EntryType.TRUST_CERT.equals(jtKeyStore.getValueAt(r, 0));
+                }
+
+                selectedCertificatesChainDetailsAction.setEnabled(hasCertEntry);
+                exportSelectedCertificatesAction.setEnabled(hasCertEntry);
+                unlockKeyAction.setEnabled(hasKeyEntry);
+
                 jpmMultiEntrySel.show(jtKeyStore, x, y);
             } else {
                 jtKeyStore.setRowSelectionInterval(row, row);


### PR DESCRIPTION
Closes #604 by reorganizing the multiple selection context menu. Adds a new option for unlocking multiple key entries at once. The organized menu looks like this:
<img width="224" height="208" alt="image" src="https://github.com/user-attachments/assets/6d6dab20-d71a-44b8-9bc3-b155fa589184" />

Let me know if a different ordering of the items is preferred.

The cert specific items are disabled if the selection does not include a cert:
<img width="367" height="237" alt="image" src="https://github.com/user-attachments/assets/f3056c1f-f5a8-482b-b471-7bc2a334235f" />

The key specific item is disabled if the selection does not include a key:
<img width="390" height="251" alt="image" src="https://github.com/user-attachments/assets/3b9ab5d2-bc5e-4385-8faf-ffc6d1060469" />
