### PR TITLE
Redraw key stores when expiry warning days is changed.

### DIFF
--- a/kse/src/main/java/org/kse/gui/actions/PreferencesAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/PreferencesAction.java
@@ -116,12 +116,20 @@ public class PreferencesAction extends ExitAction {
         boolean languageHasChanged = !language.equals(preferences.getLanguage());
         preferences.setLanguage(language);
 
+        boolean redraw = false;
         if (dPreferences.columnsChanged()) {
             preferences.setKeyStoreTableColumns(dPreferences.getColumns());
-            kseFrame.redrawKeyStores(preferences);
+            redraw = true;
         }
 
-        preferences.setExpiryWarnDays(dPreferences.getExpiryWarnDays());
+        if (preferences.getExpiryWarnDays() != dPreferences.getExpiryWarnDays()) {
+            preferences.setExpiryWarnDays(dPreferences.getExpiryWarnDays());
+            redraw = true;
+        }
+
+        if (redraw) {
+            kseFrame.redrawKeyStores(preferences);
+        }
 
         preferences.setProxySettings(updateSettings(preferences.getProxySettings()));
 


### PR DESCRIPTION
If the number of days to use for nearing expiration date is changed in the preferences, the key store tables are not updated. This PR will redraw the keystore tables so that the near expiration icon will reflect the change.