### PR TITLE
[Cert. Ext.] Decoding the `MSApplicationPolicies` (OID `1.3.6.1.4.1.311.21.10`) certificate extension value

### DIFF
--- a/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
@@ -917,7 +917,7 @@ public class X509Ext {
             sb.append(holdInstructionCodeType.friendly());
         } else {
             // Unrecognised Hold Instruction Code
-            sb.append(holdInstructionCode.getId());
+            sb.append(ObjectIdUtil.toString(holdInstructionCode));
         }
         sb.append(NEWLINE);
 
@@ -1480,7 +1480,7 @@ public class X509Ext {
                 sb.append(type.friendly());
             } else {
                 // Unrecognised key purpose ID
-                sb.append(oid);
+                sb.append(ObjectIdUtil.toString(keyPurposeId));
             }
 
             sb.append(NEWLINE);

--- a/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
@@ -1472,9 +1472,8 @@ public class X509Ext {
         ExtendedKeyUsage extendedKeyUsage = ExtendedKeyUsage.getInstance(value);
 
         for (KeyPurposeId keyPurposeId : extendedKeyUsage.getUsages()) {
-            String oid = keyPurposeId.getId();
 
-            ExtendedKeyUsageType type = ExtendedKeyUsageType.resolveOid(oid);
+            ExtendedKeyUsageType type = ExtendedKeyUsageType.resolveOid(keyPurposeId.getId());
 
             if (type != null) {
                 sb.append(type.friendly());
@@ -2747,15 +2746,14 @@ public class X509Ext {
 
         for (ASN1Encodable innerEnc : outerSeq) {
             ASN1Sequence innerSeq = ASN1Sequence.getInstance(innerEnc);
-            ASN1ObjectIdentifier keyPurposeId = ASN1ObjectIdentifier.getInstance(innerSeq.getObjectAt(0));
-            String oid = keyPurposeId.getId();
-            ExtendedKeyUsageType type = ExtendedKeyUsageType.resolveOid(oid);
+            ASN1ObjectIdentifier oid = ASN1ObjectIdentifier.getInstance(innerSeq.getObjectAt(0));
+            ExtendedKeyUsageType type = ExtendedKeyUsageType.resolveOid(oid.getId());
 
             if (type != null) {
                 sb.append(type.friendly());
             } else {
                 // Unrecognised key purpose ID
-                sb.append(ObjectIdUtil.toString(keyPurposeId));
+                sb.append(ObjectIdUtil.toString(oid));
             }
             sb.append(NEWLINE);
         }
@@ -2811,7 +2809,7 @@ public class X509Ext {
     private static String processMsNtdsCaSecurityExtSubSeq(ASN1Sequence subSeq) throws IOException {
 
         StringBuilder sb = new StringBuilder();
-        ASN1ObjectIdentifier typeOid = ASN1ObjectIdentifier.getInstance(subSeq.getObjectAt(0));
+        ASN1ObjectIdentifier typeId = ASN1ObjectIdentifier.getInstance(subSeq.getObjectAt(0));
         ASN1TaggedObject innerTagged = ASN1TaggedObject.getInstance(subSeq.getObjectAt(1));
         ASN1OctetString valueOctets;
         try {
@@ -2821,17 +2819,17 @@ public class X509Ext {
         }
         byte[] valueBytes = valueOctets.getOctets();
 
-        MSNtdsCaSecurityExtType typeOidType = MSNtdsCaSecurityExtType.resolveOid(typeOid.getId());
-        String typeOidTypeStr = null;
+        MSNtdsCaSecurityExtType typeIdType = MSNtdsCaSecurityExtType.resolveOid(typeId.getId());
+        String typeIdStr = null;
 
-        if (typeOidType != null) {
-            typeOidTypeStr = typeOidType.friendly();
+        if (typeIdType != null) {
+            typeIdStr = typeIdType.friendly();
         } else {
             // Unrecognised Type OID
-            typeOidTypeStr = ObjectIdUtil.toString(typeOid);
+            typeIdStr = ObjectIdUtil.toString(typeId);
         }
 
-        sb.append(MessageFormat.format(res.getString("MSNtdsCaSecurityExt.Type.ID"), typeOidTypeStr));
+        sb.append(MessageFormat.format(res.getString("MSNtdsCaSecurityExt.Type.ID"), typeIdStr));
         sb.append(NEWLINE);
 
         String valueStr = new String(valueBytes, StandardCharsets.UTF_8);

--- a/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
@@ -1480,7 +1480,7 @@ public class X509Ext {
                 sb.append(type.friendly());
             } else {
                 // Unrecognised key purpose ID
-                sb.append(ObjectIdUtil.toString(keyPurposeId));
+                sb.append(ObjectIdUtil.toString(keyPurposeId.toOID()));
             }
 
             sb.append(NEWLINE);


### PR DESCRIPTION
Hello KSE Team, @kaikramer

## Context
To answer to the Request on Cert. Ext.:
- #631

And to continue:
- 72b7655

## Here is a PR 
In order to:
- ✨ decode the `MSApplicationPolicies` (OID `1.3.6.1.4.1.311.21.10`) certificate extension value
- ♻️ improve [OID] variable names to be more consistent, (using `ObjectIdUtil.toString`)

## Ref.
- [Encoding a Certificate Application Policy Extension](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-wcce/160b96b1-c431-457a-8eed-27c11873f378)
- [IX509ExtensionMSApplicationPolicies](https://learn.microsoft.com/en-us/windows/win32/api/certenroll/nn-certenroll-ix509extensionmsapplicationpolicies)
- [What is the difference between `extendedKeyUsage` and an application policy?](https://security.stackexchange.com/questions/30766/what-is-the-difference-between-extendedkeyusage-and-an-application-policy)
- [The "Application Policies" certificate extension](https://www.gradenegger.eu/en/the-application-policies-certificate-extension/)

_Thanks for a review,_ 🍭
Regards,
Th.