### PR TITLE
Allow use of the verify actions without opening a key store.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -3062,8 +3062,6 @@ public final class KseFrame implements StatusBar {
         generateSecretKeyAction.setEnabled(type.supportsKeyEntries());
         importTrustedCertificateAction.setEnabled(true);
         importKeyPairAction.setEnabled(true);
-        verifySignatureAction.setEnabled(true);
-        verifyJarAction.setEnabled(true);
         propertiesAction.setEnabled(true);
         exportCsvAction.setEnabled(true);
         if (type.isFileBased()) {
@@ -3193,8 +3191,6 @@ public final class KseFrame implements StatusBar {
         generateSecretKeyAction.setEnabled(false);
         importTrustedCertificateAction.setEnabled(false);
         importKeyPairAction.setEnabled(false);
-        verifySignatureAction.setEnabled(false);
-        verifyJarAction.setEnabled(false);
         setPasswordAction.setEnabled(false);
         jmChangeType.setEnabled(false);
         propertiesAction.setEnabled(false);


### PR DESCRIPTION
This PR is a shortcut so that the user does not have to open the cacerts key store to verify a CMS or JAR signature. The verify actions are always available.