### PR TITLE
Removed JKseTable.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -19,8 +19,6 @@
  */
 package org.kse.gui;
 
-import static javax.swing.JTable.AUTO_RESIZE_ALL_COLUMNS;
-import static javax.swing.JTable.AUTO_RESIZE_NEXT_COLUMN;
 import static org.kse.crypto.keystore.KeyStoreType.BCFKS;
 import static org.kse.crypto.keystore.KeyStoreType.BKS;
 import static org.kse.crypto.keystore.KeyStoreType.JCEKS;
@@ -196,6 +194,8 @@ import org.kse.gui.preferences.data.KsePreferences;
 import org.kse.gui.quickstart.JQuickStartPane;
 import org.kse.gui.statusbar.StatusBar;
 import org.kse.gui.statusbar.StatusBarChangeHandler;
+import org.kse.gui.table.TableUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.buffer.Buffer;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -1681,9 +1681,9 @@ public final class KseFrame implements StatusBar {
         return jspKeyStoreTable;
     }
 
-    private JKseTable createEmptyKeyStoreTable() {
+    private JTable createEmptyKeyStoreTable() {
         KeyStoreTableModel ksModel = new KeyStoreTableModel(keyStoreTableColumns, preferences.getExpiryWarnDays());
-        final JKseTable jtKeyStore = new JKseTable(ksModel);
+        final JTable jtKeyStore = new ToolTipTable(ksModel);
 
         RowSorter<KeyStoreTableModel> sorter = new TableRowSorter<>(ksModel);
         jtKeyStore.setRowSorter(sorter);
@@ -1761,9 +1761,9 @@ public final class KseFrame implements StatusBar {
                                               new KeyStoreEntryDragGestureListener(this));
 
         // Add custom renderers for headers and cells
-        jtKeyStore.addCustomRenderers(keyStoreTableColumns);
+        TableUtil.addCustomRenderers(jtKeyStore, keyStoreTableColumns);
 
-        jtKeyStore.setColumnsToIconSize(0, 1, 2);
+        TableUtil.setColumnsToIconSize(jtKeyStore, 0, 1, 2);
 
         // Add mouse listener to table header for context menu
         jtKeyStore.getTableHeader().addMouseListener(new MouseAdapter() {
@@ -2667,7 +2667,7 @@ public final class KseFrame implements StatusBar {
     public void addKeyStoreHistory(KeyStoreHistory history) {
         histories.add(history);
 
-        JKseTable jtKeyStore = createEmptyKeyStoreTable();
+        JTable jtKeyStore = createEmptyKeyStoreTable();
         jtKeyStore.getSelectionModel().addListSelectionListener(event -> setDefaultStatusBarText());
         keyStoreTables.add(jtKeyStore);
 
@@ -2723,15 +2723,11 @@ public final class KseFrame implements StatusBar {
                     ksModel.load(history);
                     keyStoreTable.setModel(ksModel);
 
-                    RowSorter<KeyStoreTableModel> sorter = new TableRowSorter<>(ksModel);
-                    keyStoreTable.setRowSorter(sorter);
-                    if (keyStoreTable instanceof JKseTable) {
-                        JKseTable keyStoreTab = (JKseTable) keyStoreTable;
-                        keyStoreTab.setColumnsToIconSize(0, 1, 2);
-                        keyStoreTab.addCustomRenderers(keyStoreTableColumns);
+                    keyStoreTable.setRowSorter(new TableRowSorter<>(ksModel));
+                    TableUtil.setColumnsToIconSize(keyStoreTable, 0, 1, 2);
+                    TableUtil.addCustomRenderers(keyStoreTable, keyStoreTableColumns);
 
-                        new TableColumnAdjuster(keyStoreTab, keyStoreTableColumns).adjustColumns();
-                    }
+                    new TableColumnAdjuster(keyStoreTable, keyStoreTableColumns).adjustColumns();
                 } catch (GeneralSecurityException | CryptoException e) {
                     DError.displayError(frame, e);
                 }

--- a/kse/src/main/java/org/kse/gui/TableColumnAdjuster.java
+++ b/kse/src/main/java/org/kse/gui/TableColumnAdjuster.java
@@ -23,17 +23,13 @@ import static javax.swing.JTable.AUTO_RESIZE_ALL_COLUMNS;
 import static javax.swing.JTable.AUTO_RESIZE_NEXT_COLUMN;
 
 import java.awt.Component;
-import java.awt.event.ActionEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ResourceBundle;
 
-import javax.swing.AbstractAction;
-import javax.swing.Action;
 import javax.swing.JTable;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
@@ -50,7 +46,7 @@ import javax.swing.table.TableModel;
 public class TableColumnAdjuster implements PropertyChangeListener, TableModelListener {
     private static final ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/resources");
 
-    private final JKseTable table;
+    private final JTable table;
     private final KeyStoreTableColumns keyStoreTableColumns;
 
     private static final double FF = 0.7; // fudge factor for font size to column size
@@ -73,7 +69,7 @@ public class TableColumnAdjuster implements PropertyChangeListener, TableModelLi
     /*
      * Specify the table and use default spacing
      */
-    public TableColumnAdjuster(JKseTable table, KeyStoreTableColumns keyStoreTableColumns) {
+    public TableColumnAdjuster(JTable table, KeyStoreTableColumns keyStoreTableColumns) {
         this.table = table;
         this.keyStoreTableColumns = keyStoreTableColumns;
         setDynamicAdjustment(isDynamicAdjustment);

--- a/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
+++ b/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
@@ -30,6 +30,7 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
@@ -38,7 +39,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.components.JEscDialog;
-import org.kse.gui.JKseTable;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.gui.PlatformUtil;
 
 /**
@@ -53,7 +54,7 @@ public class DEnvironmentVariables extends JEscDialog {
     private JPanel jpOK;
     private JPanel jpEnvironmentVariablesTable;
     private JScrollPane jspEnvironmentVariablesTable;
-    private JKseTable jtEnvironmentVariables;
+    private JTable jtEnvironmentVariables;
 
     /**
      * Creates new DEnvironmentVariables dialog where the parent is a dialog.
@@ -80,12 +81,12 @@ public class DEnvironmentVariables extends JEscDialog {
         EnvironmentVariablesTableModel evModel = new EnvironmentVariablesTableModel();
         evModel.load();
 
-        jtEnvironmentVariables = new JKseTable(evModel);
+        jtEnvironmentVariables = new ToolTipTable(evModel);
 
         jtEnvironmentVariables.setRowMargin(0);
         jtEnvironmentVariables.getColumnModel().setColumnMargin(0);
         jtEnvironmentVariables.getTableHeader().setReorderingAllowed(false);
-        jtEnvironmentVariables.setAutoResizeMode(JKseTable.AUTO_RESIZE_OFF);
+        jtEnvironmentVariables.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
         RowSorter<EnvironmentVariablesTableModel> sorter = new TableRowSorter<>(evModel);
         jtEnvironmentVariables.setRowSorter(sorter);

--- a/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
+++ b/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
@@ -30,6 +30,7 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
@@ -38,7 +39,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.components.JEscDialog;
-import org.kse.gui.JKseTable;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.gui.PlatformUtil;
 
 /**
@@ -53,7 +54,7 @@ public class DSystemProperties extends JEscDialog {
     private JPanel jpOK;
     private JPanel jpSystemPropertiesTable;
     private JScrollPane jspSystemPropertiesTable;
-    private JKseTable jtSystemProperties;
+    private JTable jtSystemProperties;
 
     /**
      * Creates new DSystemProperties dialog where the parent is a dialog.
@@ -80,12 +81,12 @@ public class DSystemProperties extends JEscDialog {
         SystemPropertiesTableModel spModel = new SystemPropertiesTableModel();
         spModel.load();
 
-        jtSystemProperties = new JKseTable(spModel);
+        jtSystemProperties = new ToolTipTable(spModel);
 
         jtSystemProperties.setRowMargin(0);
         jtSystemProperties.getColumnModel().setColumnMargin(0);
         jtSystemProperties.getTableHeader().setReorderingAllowed(false);
-        jtSystemProperties.setAutoResizeMode(JKseTable.AUTO_RESIZE_OFF);
+        jtSystemProperties.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
         RowSorter<SystemPropertiesTableModel> sorter = new TableRowSorter<>(spModel);
         jtSystemProperties.setRowSorter(sorter);

--- a/kse/src/main/java/org/kse/gui/crypto/accessdescription/JAccessDescriptions.java
+++ b/kse/src/main/java/org/kse/gui/crypto/accessdescription/JAccessDescriptions.java
@@ -41,6 +41,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -48,8 +49,8 @@ import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.x509.AccessDescription;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -65,7 +66,7 @@ public class JAccessDescriptions extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspAccessDescriptions;
-    private JKseTable jtAccessDescriptions;
+    private JTable jtAccessDescriptions;
 
     private String title;
     private List<AccessDescription> accessDescriptions;
@@ -142,7 +143,7 @@ public class JAccessDescriptions extends JPanel {
         jpAccessDescriptionButtons.add(Box.createVerticalGlue());
 
         AccessDescriptionsTableModel accessDescriptionsTableModel = new AccessDescriptionsTableModel();
-        jtAccessDescriptions = new JKseTable(accessDescriptionsTableModel);
+        jtAccessDescriptions = new ToolTipTable(accessDescriptionsTableModel);
 
         TableRowSorter<AccessDescriptionsTableModel> sorter = new TableRowSorter<>(accessDescriptionsTableModel);
         sorter.setComparator(0, new AccessDescriptionsTableModel.AccessDescriptionMethodComparator());
@@ -153,7 +154,7 @@ public class JAccessDescriptions extends JPanel {
         jtAccessDescriptions.setRowMargin(0);
         jtAccessDescriptions.getColumnModel().setColumnMargin(0);
         jtAccessDescriptions.getTableHeader().setReorderingAllowed(false);
-        jtAccessDescriptions.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtAccessDescriptions.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtAccessDescriptions.setRowHeight(Math.max(18, jtAccessDescriptions.getRowHeight()));
 
         for (int i = 0; i < jtAccessDescriptions.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/crypto/customextkeyusage/JCustomExtendedKeyUsage.java
+++ b/kse/src/main/java/org/kse/gui/crypto/customextkeyusage/JCustomExtendedKeyUsage.java
@@ -41,6 +41,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -48,10 +49,10 @@ import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.error.DError;
 import org.kse.gui.oid.DObjectIdChooser;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.oid.InvalidObjectIdException;
 import org.kse.utilities.oid.ObjectIdComparator;
 import org.kse.utilities.os.OperatingSystem;
@@ -69,7 +70,7 @@ public class JCustomExtendedKeyUsage extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspCustomExtKeyUsage;
-    private JKseTable jtCustomExtKeyUsages;
+    private JTable jtCustomExtKeyUsages;
 
     private String title;
     private Set<ASN1ObjectIdentifier> objectIds;
@@ -147,7 +148,7 @@ public class JCustomExtendedKeyUsage extends JPanel {
         jpCustomExtKeyUsageButtons.add(Box.createVerticalGlue());
 
         CustomExtKeyUsageTableModel customExtKeyUsageTableModel = new CustomExtKeyUsageTableModel();
-        jtCustomExtKeyUsages = new JKseTable(customExtKeyUsageTableModel);
+        jtCustomExtKeyUsages = new ToolTipTable(customExtKeyUsageTableModel);
 
         TableRowSorter<CustomExtKeyUsageTableModel> sorter = new TableRowSorter<>(customExtKeyUsageTableModel);
         sorter.setComparator(0, new ObjectIdComparator());
@@ -157,7 +158,7 @@ public class JCustomExtendedKeyUsage extends JPanel {
         jtCustomExtKeyUsages.setRowMargin(0);
         jtCustomExtKeyUsages.getColumnModel().setColumnMargin(0);
         jtCustomExtKeyUsages.getTableHeader().setReorderingAllowed(false);
-        jtCustomExtKeyUsages.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtCustomExtKeyUsages.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtCustomExtKeyUsages.setRowHeight(Math.max(18, jtCustomExtKeyUsages.getRowHeight()));
 
         for (int i = 0; i < jtCustomExtKeyUsages.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/crypto/distributionpoints/JDistributionPoints.java
+++ b/kse/src/main/java/org/kse/gui/crypto/distributionpoints/JDistributionPoints.java
@@ -40,6 +40,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -48,10 +49,13 @@ import javax.swing.table.TableRowSorter;
 import org.bouncycastle.asn1.x509.CRLDistPoint;
 import org.bouncycastle.asn1.x509.DistributionPoint;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
+/**
+ * Component to show the list distribution points.
+ */
 public class JDistributionPoints extends JPanel {
 
     private static final long serialVersionUID = 1L;
@@ -62,11 +66,16 @@ public class JDistributionPoints extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspDistributionPoints;
-    private JKseTable jtDistributionPoints;
+    private JTable jtDistributionPoints;
 
     private String title;
     private boolean enabled = true;
 
+    /**
+     * Creates a new JDistributionPoints
+     *
+     * @param title The title of the window.
+     */
     public JDistributionPoints(String title) {
         this.title = title;
         initComponents();
@@ -133,7 +142,7 @@ public class JDistributionPoints extends JPanel {
         jpDistributionPointsButtons.add(Box.createVerticalGlue());
 
         DistributionPointsTableModel distributionPointsTableModel = new DistributionPointsTableModel();
-        jtDistributionPoints = new JKseTable(distributionPointsTableModel);
+        jtDistributionPoints = new ToolTipTable(distributionPointsTableModel);
 
         TableRowSorter<DistributionPointsTableModel> sorter = new TableRowSorter<>(distributionPointsTableModel);
         sorter.setComparator(0, new DistributionPointsTableModel.DistributionPointComparator());
@@ -143,7 +152,7 @@ public class JDistributionPoints extends JPanel {
         jtDistributionPoints.setRowMargin(0);
         jtDistributionPoints.getColumnModel().setColumnMargin(0);
         jtDistributionPoints.getTableHeader().setReorderingAllowed(false);
-        jtDistributionPoints.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtDistributionPoints.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtDistributionPoints.setRowHeight(Math.max(18, jtDistributionPoints.getRowHeight()));
 
         for (int i = 0; i < jtDistributionPoints.getColumnCount(); i++) {
@@ -219,10 +228,18 @@ public class JDistributionPoints extends JPanel {
         updateButtonControls();
     }
 
+    /**
+     * @return A CRLDistPoint populated from the table.
+     */
     public CRLDistPoint getCRLDistPoint() {
         return new CRLDistPoint(getDistributionPointsTableModel().getData().toArray(new DistributionPoint[0]));
     }
 
+    /**
+     * Populates the table with the distribution points in cRLDistPoint.
+     *
+     * @param cRLDistPoint The distribution points to load.
+     */
     public void setCRLDistPoint(CRLDistPoint cRLDistPoint) {
         getDistributionPointsTableModel().load(cRLDistPoint);
     }

--- a/kse/src/main/java/org/kse/gui/crypto/generalname/DGeneralNameChooser.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/DGeneralNameChooser.java
@@ -20,8 +20,8 @@
 package org.kse.gui.crypto.generalname;
 
 import java.awt.Container;
-import java.awt.Dialog;
 import java.awt.FlowLayout;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.util.ResourceBundle;
@@ -30,8 +30,6 @@ import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -96,24 +94,12 @@ public class DGeneralNameChooser extends JEscDialog {
     /**
      * Constructs a new DGeneralNameChooser dialog.
      *
-     * @param parent      The parent frame
+     * @param parent      The parent window
      * @param title       The dialog title
      * @param generalName General name
      */
-    public DGeneralNameChooser(JFrame parent, String title, GeneralName generalName) {
+    public DGeneralNameChooser(Window parent, String title, GeneralName generalName) {
         super(parent, title, ModalityType.DOCUMENT_MODAL);
-        initComponents(generalName);
-    }
-
-    /**
-     * Constructs a new DGeneralNameChooser dialog.
-     *
-     * @param parent      The parent dialog
-     * @param title       The dialog title
-     * @param generalName General name
-     */
-    public DGeneralNameChooser(JDialog parent, String title, GeneralName generalName) {
-        super(parent, title, Dialog.ModalityType.DOCUMENT_MODAL);
         initComponents(generalName);
     }
 

--- a/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalname/JGeneralNames.java
@@ -25,6 +25,7 @@ import java.awt.Dimension;
 import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Toolkit;
+import java.awt.Window;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
@@ -39,6 +40,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -47,8 +49,8 @@ import javax.swing.table.TableRowSorter;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -64,7 +66,7 @@ public class JGeneralNames extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspGeneralNames;
-    private JKseTable jtGeneralNames;
+    private JTable jtGeneralNames;
 
     private String title;
     private boolean enabled = true;
@@ -140,7 +142,7 @@ public class JGeneralNames extends JPanel {
         jpGeneralNameButtons.add(Box.createVerticalGlue());
 
         GeneralNamesTableModel generalNamesTableModel = new GeneralNamesTableModel();
-        jtGeneralNames = new JKseTable(generalNamesTableModel);
+        jtGeneralNames = new ToolTipTable(generalNamesTableModel);
 
         TableRowSorter<GeneralNamesTableModel> sorter = new TableRowSorter<>(generalNamesTableModel);
         sorter.setComparator(0, new GeneralNamesTableModel.GeneralNameComparator());
@@ -150,7 +152,7 @@ public class JGeneralNames extends JPanel {
         jtGeneralNames.setRowMargin(0);
         jtGeneralNames.getColumnModel().setColumnMargin(0);
         jtGeneralNames.getTableHeader().setReorderingAllowed(false);
-        jtGeneralNames.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtGeneralNames.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtGeneralNames.setRowHeight(Math.max(18, jtGeneralNames.getRowHeight()));
 
         for (int i = 0; i < jtGeneralNames.getColumnCount(); i++) {
@@ -357,13 +359,7 @@ public class JGeneralNames extends JPanel {
 
             Container container = getTopLevelAncestor();
 
-            DGeneralNameChooser dGeneralNameChooser = null;
-
-            if (container instanceof JDialog) {
-                dGeneralNameChooser = new DGeneralNameChooser((JDialog) container, title, generalName);
-            } else if (container instanceof JFrame) {
-                dGeneralNameChooser = new DGeneralNameChooser((JFrame) container, title, generalName);
-            }
+            DGeneralNameChooser dGeneralNameChooser = new DGeneralNameChooser((Window) container, title, generalName);
             dGeneralNameChooser.setLocationRelativeTo(container);
             dGeneralNameChooser.setVisible(true);
 

--- a/kse/src/main/java/org/kse/gui/crypto/generalsubtree/JGeneralSubtrees.java
+++ b/kse/src/main/java/org/kse/gui/crypto/generalsubtree/JGeneralSubtrees.java
@@ -40,6 +40,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -48,8 +49,8 @@ import javax.swing.table.TableRowSorter;
 import org.bouncycastle.asn1.x509.GeneralSubtree;
 import org.kse.crypto.x509.GeneralSubtrees;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -65,7 +66,7 @@ public class JGeneralSubtrees extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspGeneralSubtrees;
-    private JKseTable jtGeneralSubtrees;
+    private JTable jtGeneralSubtrees;
 
     private String title;
     private GeneralSubtrees generalSubtrees;
@@ -142,7 +143,7 @@ public class JGeneralSubtrees extends JPanel {
         jpGeneralSubtreeButtons.add(Box.createVerticalGlue());
 
         GeneralSubtreesTableModel generalSubtreesTableModel = new GeneralSubtreesTableModel();
-        jtGeneralSubtrees = new JKseTable(generalSubtreesTableModel);
+        jtGeneralSubtrees = new ToolTipTable(generalSubtreesTableModel);
 
         TableRowSorter<GeneralSubtreesTableModel> sorter = new TableRowSorter<>(generalSubtreesTableModel);
         sorter.setComparator(0, new GeneralSubtreesTableModel.GeneralSubtreeBaseComparator());
@@ -154,7 +155,7 @@ public class JGeneralSubtrees extends JPanel {
         jtGeneralSubtrees.setRowMargin(0);
         jtGeneralSubtrees.getColumnModel().setColumnMargin(0);
         jtGeneralSubtrees.getTableHeader().setReorderingAllowed(false);
-        jtGeneralSubtrees.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtGeneralSubtrees.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtGeneralSubtrees.setRowHeight(Math.max(18, jtGeneralSubtrees.getRowHeight()));
 
         for (int i = 0; i < jtGeneralSubtrees.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/crypto/policyinformation/JPolicyInformation.java
+++ b/kse/src/main/java/org/kse/gui/crypto/policyinformation/JPolicyInformation.java
@@ -42,6 +42,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -49,9 +50,9 @@ import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.x509.PolicyInformation;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.error.DError;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -67,7 +68,7 @@ public class JPolicyInformation extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspPolicyInformation;
-    private JKseTable jtPolicyInformation;
+    private JTable jtPolicyInformation;
 
     private String title;
     private List<PolicyInformation> policyInformation;
@@ -144,7 +145,7 @@ public class JPolicyInformation extends JPanel {
         jpPolicyInformationButtons.add(Box.createVerticalGlue());
 
         PolicyInformationTableModel policyInformationTableModel = new PolicyInformationTableModel();
-        jtPolicyInformation = new JKseTable(policyInformationTableModel);
+        jtPolicyInformation = new ToolTipTable(policyInformationTableModel);
 
         TableRowSorter<PolicyInformationTableModel> sorter = new TableRowSorter<>(policyInformationTableModel);
         sorter.setComparator(0, new PolicyInformationTableModel.PolicyInformationComparator());
@@ -154,7 +155,7 @@ public class JPolicyInformation extends JPanel {
         jtPolicyInformation.setRowMargin(0);
         jtPolicyInformation.getColumnModel().setColumnMargin(0);
         jtPolicyInformation.getTableHeader().setReorderingAllowed(false);
-        jtPolicyInformation.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtPolicyInformation.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtPolicyInformation.setRowHeight(Math.max(18, jtPolicyInformation.getRowHeight()));
 
         for (int i = 0; i < jtPolicyInformation.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/crypto/policyinformation/JPolicyQualifierInfo.java
+++ b/kse/src/main/java/org/kse/gui/crypto/policyinformation/JPolicyQualifierInfo.java
@@ -42,6 +42,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -49,9 +50,9 @@ import javax.swing.table.TableRowSorter;
 
 import org.bouncycastle.asn1.x509.PolicyQualifierInfo;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.error.DError;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -67,7 +68,7 @@ public class JPolicyQualifierInfo extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspPolicyQualifierInfo;
-    private JKseTable jtPolicyQualifierInfo;
+    private JTable jtPolicyQualifierInfo;
 
     private String title;
     private List<PolicyQualifierInfo> policyQualifierInfo;
@@ -144,7 +145,7 @@ public class JPolicyQualifierInfo extends JPanel {
         jpPolicyQualifierInfoButtons.add(Box.createVerticalGlue());
 
         PolicyQualifierInfoTableModel policyQualifierInfoTableModel = new PolicyQualifierInfoTableModel();
-        jtPolicyQualifierInfo = new JKseTable(policyQualifierInfoTableModel);
+        jtPolicyQualifierInfo = new ToolTipTable(policyQualifierInfoTableModel);
 
         TableRowSorter<PolicyQualifierInfoTableModel> sorter = new TableRowSorter<>(policyQualifierInfoTableModel);
         sorter.setComparator(0, new PolicyQualifierInfoTableModel.PolicyQualifierInfoComparator());
@@ -154,7 +155,7 @@ public class JPolicyQualifierInfo extends JPanel {
         jtPolicyQualifierInfo.setRowMargin(0);
         jtPolicyQualifierInfo.getColumnModel().setColumnMargin(0);
         jtPolicyQualifierInfo.getTableHeader().setReorderingAllowed(false);
-        jtPolicyQualifierInfo.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtPolicyQualifierInfo.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtPolicyQualifierInfo.setRowHeight(Math.max(18, jtPolicyQualifierInfo.getRowHeight()));
 
         for (int i = 0; i < jtPolicyQualifierInfo.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/crypto/policymapping/JPolicyMappings.java
+++ b/kse/src/main/java/org/kse/gui/crypto/policymapping/JPolicyMappings.java
@@ -39,6 +39,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableColumn;
@@ -49,8 +50,8 @@ import org.bouncycastle.asn1.x509.PolicyMappings;
 import org.kse.crypto.x509.PolicyMapping;
 import org.kse.crypto.x509.PolicyMappingsUtil;
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.os.OperatingSystem;
 
 /**
@@ -66,7 +67,7 @@ public class JPolicyMappings extends JPanel {
     private JButton jbEdit;
     private JButton jbRemove;
     private JScrollPane jspPolicyMappings;
-    private JKseTable jtPolicyMappings;
+    private JTable jtPolicyMappings;
 
     private String title;
     private PolicyMappings policyMappings;
@@ -143,7 +144,7 @@ public class JPolicyMappings extends JPanel {
         jpPolicyMappingButtons.add(Box.createVerticalGlue());
 
         PolicyMappingsTableModel policyMappingsTableModel = new PolicyMappingsTableModel();
-        jtPolicyMappings = new JKseTable(policyMappingsTableModel);
+        jtPolicyMappings = new ToolTipTable(policyMappingsTableModel);
 
         TableRowSorter<PolicyMappingsTableModel> sorter = new TableRowSorter<>(policyMappingsTableModel);
         sorter.setComparator(0, new PolicyMappingsTableModel.IssuerDomainPolicyComparator());
@@ -154,7 +155,7 @@ public class JPolicyMappings extends JPanel {
         jtPolicyMappings.setRowMargin(0);
         jtPolicyMappings.getColumnModel().setColumnMargin(0);
         jtPolicyMappings.getTableHeader().setReorderingAllowed(false);
-        jtPolicyMappings.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtPolicyMappings.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtPolicyMappings.setRowHeight(Math.max(18, jtPolicyMappings.getRowHeight()));
 
         for (int i = 0; i < jtPolicyMappings.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
@@ -54,6 +54,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSeparator;
+import javax.swing.JTable;
 import javax.swing.KeyStroke;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
@@ -88,10 +89,10 @@ import org.kse.crypto.x509.X509ExtensionType;
 import org.kse.gui.CurrentDirectory;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.FileChooserFactory;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.components.JEscDialog;
 import org.kse.gui.error.DError;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.oid.ObjectIdComparator;
 import org.kse.utilities.os.OperatingSystem;
@@ -113,7 +114,7 @@ public class DAddExtensions extends JEscDialog {
     private JButton jbToggleCriticality;
     private JButton jbRemove;
     private JScrollPane jspExtensionsTable;
-    private JKseTable jtExtensions;
+    private JTable jtExtensions;
     private JButton jbSelectStandardTemplate;
     private JButton jbLoadTemplate;
     private JButton jbSaveTemplate;
@@ -254,7 +255,7 @@ public class DAddExtensions extends JEscDialog {
         });
 
         ExtensionsTableModel extensionsTableModel = new ExtensionsTableModel();
-        jtExtensions = new JKseTable(extensionsTableModel);
+        jtExtensions = new ToolTipTable(extensionsTableModel);
 
         TableRowSorter<ExtensionsTableModel> sorter = new TableRowSorter<>(extensionsTableModel);
         sorter.setComparator(2, new ObjectIdComparator());
@@ -264,7 +265,7 @@ public class DAddExtensions extends JEscDialog {
         jtExtensions.setRowMargin(0);
         jtExtensions.getColumnModel().setColumnMargin(0);
         jtExtensions.getTableHeader().setReorderingAllowed(false);
-        jtExtensions.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtExtensions.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtExtensions.setRowHeight(Math.max(18, jtExtensions.getRowHeight()));
 
         for (int i = 0; i < jtExtensions.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DViewExtensions.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DViewExtensions.java
@@ -45,6 +45,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
@@ -64,7 +65,6 @@ import org.kse.crypto.x509.X509Ext;
 import org.kse.crypto.x509.X509ExtensionSet;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.components.JEscDialog;
-import org.kse.gui.JKseTable;
 import org.kse.gui.KseFrame;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
@@ -72,6 +72,7 @@ import org.kse.gui.dialogs.DViewAsn1Dump;
 import org.kse.gui.dialogs.DViewCertificate;
 import org.kse.gui.dialogs.DViewCrl;
 import org.kse.gui.error.DError;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.asn1.Asn1Exception;
 import org.kse.utilities.oid.ObjectIdComparator;
 
@@ -86,7 +87,7 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
     private JPanel jpExtensions;
     private JPanel jpExtensionsTable;
     private JScrollPane jspExtensionsTable;
-    private JKseTable jtExtensions;
+    private JTable jtExtensions;
     private JPanel jpExtensionValue;
     private JLabel jlExtensionValue;
     private JPanel jpExtensionValueTextArea;
@@ -142,7 +143,7 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
 
     private void initComponents() {
         ExtensionsTableModel extensionsTableModel = new ExtensionsTableModel();
-        jtExtensions = new JKseTable(extensionsTableModel);
+        jtExtensions = new ToolTipTable(extensionsTableModel);
 
         TableRowSorter<ExtensionsTableModel> sorter = new TableRowSorter<>(extensionsTableModel);
         sorter.setComparator(2, new ObjectIdComparator());
@@ -152,7 +153,7 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
         jtExtensions.setRowMargin(0);
         jtExtensions.getColumnModel().setColumnMargin(0);
         jtExtensions.getTableHeader().setReorderingAllowed(false);
-        jtExtensions.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtExtensions.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
         jtExtensions.setRowHeight(Math.max(18, jtExtensions.getRowHeight()));
 
         for (int i = 0; i < jtExtensions.getColumnCount(); i++) {

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
@@ -192,6 +192,9 @@ public class DListCertificatesKS extends JEscDialog {
         closeDialog();
     }
 
+    /**
+     * @return The selected certificate.
+     */
     public X509Certificate getCertificate() {
         return cert;
     }

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/JClaims.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/JClaims.java
@@ -27,6 +27,7 @@ import java.awt.Point;
 import java.awt.Toolkit;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.Collections;
 import java.util.List;
 import java.util.ResourceBundle;
 
@@ -38,6 +39,7 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
@@ -48,8 +50,8 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.CursorUtil;
-import org.kse.gui.JKseTable;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.table.ToolTipTable;
 
 /**
  * Component to show the list of custom claims
@@ -62,7 +64,7 @@ public class JClaims extends JPanel {
     private JFrame parent;
     private JLabel jlClaims;
     private JScrollPane jspClaimsTable;
-    private JKseTable jtClaims;
+    private JTable jtClaims;
 
     private JPanel jpClaimsButtons;
     private JButton jbAdd;
@@ -134,7 +136,7 @@ public class JClaims extends JPanel {
         jlClaims = new JLabel(res.getString("JClaims.jlClaims.text"));
         ListClaimsTableModel rcModel = new ListClaimsTableModel();
 
-        jtClaims = new JKseTable(rcModel);
+        jtClaims = new ToolTipTable(rcModel);
         ListSelectionModel selectionModel = jtClaims.getSelectionModel();
         selectionModel.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
         selectionModel.addListSelectionListener(evt -> {
@@ -155,7 +157,7 @@ public class JClaims extends JPanel {
         jtClaims.setRowMargin(0);
         jtClaims.getColumnModel().setColumnMargin(0);
         jtClaims.getTableHeader().setReorderingAllowed(false);
-        jtClaims.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtClaims.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 
         for (int i = 0; i < jtClaims.getColumnCount(); i++) {
             TableColumn column = jtClaims.getColumnModel().getColumn(i);
@@ -256,9 +258,12 @@ public class JClaims extends JPanel {
         }
     }
 
+    /**
+     * @return An unmodifiable list of custom claims.
+     */
     public List<CustomClaim> getCustomClaims() {
         ListClaimsTableModel model = getCustomClaimTableModel();
-        return model.getData();
+        return Collections.unmodifiableList(model.getData());
     }
 
     private void updateButtonControls() {

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/JListCertificates.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/JListCertificates.java
@@ -29,19 +29,21 @@ import java.security.cert.X509Certificate;
 
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.crypto.CryptoException;
-import org.kse.gui.JKseTable;
 import org.kse.gui.KeyStoreTableColumns;
 import org.kse.gui.KeyStoreTableModel;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.TableColumnAdjuster;
 import org.kse.gui.preferences.PreferencesManager;
 import org.kse.gui.preferences.data.KsePreferences;
+import org.kse.gui.table.TableUtil;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.history.KeyStoreHistory;
 
 /**
@@ -51,7 +53,7 @@ public class JListCertificates extends JPanel {
 
     private static final long serialVersionUID = 1L;
     private JScrollPane jspListCertsTable;
-    private JKseTable jtListCerts;
+    private JTable jtListCerts;
 
     private KsePreferences preferences = PreferencesManager.getPreferences();
 
@@ -71,7 +73,7 @@ public class JListCertificates extends JPanel {
         keyStoreTableColumns = preferences.getKeyStoreTableColumns();
         KeyStoreTableModel ksModel = new KeyStoreTableModel(keyStoreTableColumns, preferences.getExpiryWarnDays());
 
-        jtListCerts = new JKseTable(ksModel);
+        jtListCerts = new ToolTipTable(ksModel);
         RowSorter<KeyStoreTableModel> sorter = new TableRowSorter<>(ksModel);
         jtListCerts.setRowSorter(sorter);
 
@@ -79,8 +81,8 @@ public class JListCertificates extends JPanel {
         jtListCerts.setSelectionMode(ListSelectionModel.SINGLE_INTERVAL_SELECTION);
         jtListCerts.getTableHeader().setReorderingAllowed(false);
         jtListCerts.setRowHeight(Math.max(18, jtListCerts.getRowHeight())); // min. height of 18 because of 16x16 icons
-        jtListCerts.setColumnsToIconSize(0, 1, 2);
-        jtListCerts.addCustomRenderers(keyStoreTableColumns);
+        TableUtil.setColumnsToIconSize(jtListCerts, 0, 1, 2);
+        TableUtil.addCustomRenderers(jtListCerts, keyStoreTableColumns);
 
         new TableColumnAdjuster(jtListCerts, keyStoreTableColumns).adjustColumns();
 
@@ -93,6 +95,10 @@ public class JListCertificates extends JPanel {
         this.add(jspListCertsTable, BorderLayout.CENTER);
     }
 
+    /**
+     * Updates the table with the certificates from the currently selected key store.
+     * @param keyStoreHistory The KeyStoreHistory to load.
+     */
     public void load(KeyStoreHistory keyStoreHistory) {
 
         if (keyStoreHistory != null) {
@@ -106,7 +112,7 @@ public class JListCertificates extends JPanel {
         }
     }
 
-    public String getSelectedEntryAlias() {
+    private String getSelectedEntryAlias() {
         int row = jtListCerts.getSelectedRow();
 
         if (row == -1) {
@@ -116,6 +122,10 @@ public class JListCertificates extends JPanel {
         return (String) jtListCerts.getValueAt(row, 3);
     }
 
+    /**
+     *
+     * @return The currently selected certificate, else null if no certificate is selected.
+     */
     public X509Certificate getSelectedCert() {
         int pos = jtListCerts.getSelectedRow();
         if (pos >= 0) {
@@ -129,7 +139,11 @@ public class JListCertificates extends JPanel {
         return null;
     }
 
-    public JKseTable getJtListCerts() {
+    /**
+     *
+     * @return The JTable backing the list of certificates.
+     */
+    public JTable getJtListCerts() {
         return jtListCerts;
     }
 }

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/JRevokedCerts.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/JRevokedCerts.java
@@ -38,6 +38,7 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -55,6 +56,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.border.CompoundBorder;
@@ -71,13 +73,13 @@ import org.kse.crypto.filetype.CryptoFileUtil;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CurrentDirectory;
 import org.kse.gui.FileChooserFactory;
-import org.kse.gui.JKseTable;
 import org.kse.gui.KseFrame;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.dialogs.RevokedCertsTableCellRend;
 import org.kse.gui.dialogs.RevokedCertsTableModel;
 import org.kse.gui.error.DProblem;
 import org.kse.gui.error.Problem;
+import org.kse.gui.table.ToolTipTable;
 
 /**
  * Component to show the list of certificates revoked
@@ -89,7 +91,7 @@ public class JRevokedCerts extends JPanel {
 
     private JLabel jlRevokedCerts;
     private JScrollPane jspRevokedCertsTable;
-    private JKseTable jtRevokedCerts;
+    private JTable jtRevokedCerts;
 
     private JPanel jpRevokedButtons;
     private JButton jbRevCertFile;
@@ -141,7 +143,7 @@ public class JRevokedCerts extends JPanel {
         jlRevokedCerts = new JLabel(res.getString("JRevokedCerts.jlRevokedCerts.text"));
         RevokedCertsTableModel rcModel = new RevokedCertsTableModel();
 
-        jtRevokedCerts = new JKseTable(rcModel);
+        jtRevokedCerts = new ToolTipTable(rcModel);
         RowSorter<RevokedCertsTableModel> sorter = new TableRowSorter<>(rcModel);
         jtRevokedCerts.setRowSorter(sorter);
 
@@ -149,7 +151,7 @@ public class JRevokedCerts extends JPanel {
         jtRevokedCerts.setRowMargin(0);
         jtRevokedCerts.getColumnModel().setColumnMargin(0);
         jtRevokedCerts.getTableHeader().setReorderingAllowed(false);
-        jtRevokedCerts.setAutoResizeMode(JKseTable.AUTO_RESIZE_ALL_COLUMNS);
+        jtRevokedCerts.setAutoResizeMode(JTable.AUTO_RESIZE_ALL_COLUMNS);
 
         for (int i = 0; i < jtRevokedCerts.getColumnCount(); i++) {
             TableColumn column = jtRevokedCerts.getColumnModel().getColumn(i);
@@ -397,8 +399,13 @@ public class JRevokedCerts extends JPanel {
         return null;
     }
 
+    /**
+     * Exposes a read-only view of the revoked certificates map.
+     *
+     * @return An unmodifiable map of revoked certificate.
+     */
     public Map<BigInteger, RevokedEntry> getMapRevokedEntry() {
-        return mapRevokedEntry;
+        return Collections.unmodifiableMap(mapRevokedEntry);
     }
 
 }

--- a/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
+++ b/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
@@ -37,6 +37,7 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
@@ -45,7 +46,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.components.JEscDialog;
-import org.kse.gui.JKseTable;
+import org.kse.gui.table.ToolTipTable;
 import org.kse.gui.PlatformUtil;
 
 /**
@@ -60,7 +61,7 @@ public class DJarInfo extends JEscDialog {
     private JPanel jpOK;
     private JPanel jpJarInfoTable;
     private JScrollPane jspJarInfoTable;
-    private JKseTable jtJarInfo;
+    private JTable jtJarInfo;
 
     /**
      * Creates new DJarInfo dialog where the parent is a frame.
@@ -91,12 +92,12 @@ public class DJarInfo extends JEscDialog {
         JarInfoTableModel jiModel = new JarInfoTableModel();
         jiModel.load(jarFiles);
 
-        jtJarInfo = new JKseTable(jiModel);
+        jtJarInfo = new ToolTipTable(jiModel);
 
         jtJarInfo.setRowMargin(0);
         jtJarInfo.getColumnModel().setColumnMargin(0);
         jtJarInfo.getTableHeader().setReorderingAllowed(false);
-        jtJarInfo.setAutoResizeMode(JKseTable.AUTO_RESIZE_OFF);
+        jtJarInfo.setAutoResizeMode(JTable.AUTO_RESIZE_OFF);
 
         RowSorter<JarInfoTableModel> sorter = new TableRowSorter<>(jiModel);
         jtJarInfo.setRowSorter(sorter);

--- a/kse/src/main/java/org/kse/gui/table/TableUtil.java
+++ b/kse/src/main/java/org/kse/gui/table/TableUtil.java
@@ -17,7 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.kse.gui;
+
+package org.kse.gui.table;
 
 import java.awt.BorderLayout;
 import java.util.ResourceBundle;
@@ -25,41 +26,36 @@ import java.util.ResourceBundle;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
+import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.TableColumn;
 
-import org.kse.gui.table.ToolTipTable;
-import org.kse.gui.table.ToolTipTableModel;
+import org.kse.gui.KeyStoreTableCellRend;
+import org.kse.gui.KeyStoreTableColumns;
+import org.kse.gui.KeyStoreTableHeadRend;
+import org.kse.gui.TableColumnAdjuster;
 
-public class JKseTable extends ToolTipTable {
+/**
+ * A utility class for common table functions.
+ */
+public class TableUtil {
 
-    private static final long serialVersionUID = 6624687599136560793L;
     private static final int ICON_SIZE = 28;
 
+    // Utility pattern
+    private TableUtil() {}
+
     /**
-     * @param tableModel
+     * Resizes a given set of column numbers to the icon size.
+     * @param table The table with columns displaying icons.
+     * @param columnNumbers The columns of the table that will display icons.
      */
-    public JKseTable(ToolTipTableModel tableModel) {
-        super(tableModel);
-        fixRowHeight();
-    }
-
-    private JKseTable(Object[][] rowData, Object[] columnNames) {
-        super(rowData, columnNames);
-        fixRowHeight();
-    }
-
-    private void fixRowHeight() {
-        // workaround for default rowHeight not DPI scaled (https://bugs.openjdk.java.net/browse/JDK-8029087)
-        int fontHeight = getFontMetrics(getFont()).getHeight();
-        setRowHeight(fontHeight + (int) (0.2 * fontHeight + 0.5));
-    }
-
-    public void setColumnsToIconSize(int... columnNumbers) {
+    public static void setColumnsToIconSize(JTable table, int... columnNumbers) {
         for (int i : columnNumbers) {
-            TableColumn typeCol = getColumnModel().getColumn(i);
+            TableColumn typeCol = table.getColumnModel().getColumn(i);
             typeCol.setResizable(false);
             typeCol.setMinWidth(ICON_SIZE);
             typeCol.setMaxWidth(ICON_SIZE);
@@ -67,12 +63,17 @@ public class JKseTable extends ToolTipTable {
         }
     }
 
-    public void addCustomRenderers(KeyStoreTableColumns keyStoreTableColumns) {
-        for (int i = 0; i < getColumnCount(); i++) {
-            TableColumn column = getColumnModel().getColumn(i);
+    /**
+     * Adds the customer renderers for tables that use the KeyStoreTableColumns.
+     * @param table The table configurable by KeyStoreTableColumns.
+     * @param keyStoreTableColumns The KeyStoreTableColumns for the table.
+     */
+    public static void addCustomRenderers(JTable table, KeyStoreTableColumns keyStoreTableColumns) {
+        for (int i = 0; i < table.getColumnCount(); i++) {
+            TableColumn column = table.getColumnModel().getColumn(i);
 
             column.setHeaderRenderer(
-                    new KeyStoreTableHeadRend(getTableHeader().getDefaultRenderer(), keyStoreTableColumns));
+                    new KeyStoreTableHeadRend(table.getTableHeader().getDefaultRenderer(), keyStoreTableColumns));
             column.setCellRenderer(new KeyStoreTableCellRend());
         }
     }
@@ -82,8 +83,8 @@ public class JKseTable extends ToolTipTable {
         ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/resources");
 
         javax.swing.SwingUtilities.invokeLater(() -> {
-            JFrame frame = new JFrame("JKseTable");
-            frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+            JFrame frame = new JFrame("KseTable");
+            frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
 
             String[] columnNames = { "T", "L", "E", res.getString("KeyStoreTableModel.NameColumn"),
                                      res.getString("KeyStoreTableModel.AlgorithmColumn"),
@@ -92,23 +93,23 @@ public class JKseTable extends ToolTipTable {
                                      res.getString("KeyStoreTableModel.SubjectDNColumn"),
                                      res.getString("KeyStoreTableModel.LastModifiedColumn"), };
             Object[][] data = {
-                    { "\uD83D\uDD11", "❌", "\uD83D\uDD13", "mykey", "RSA", "2048", "2025-12-31",
-                      "CN=Subject A, O=Organisation A, C=UK", "2024-01-15" },
-                    { "\uD83D\uDDCE", "✅", "\uD83D\uDD13", "trustedcert", "RSA", "4096", "2026-06-30",
+                    { "KEY_PAIR", false, "NOT_EXPIRED", "mykey", "RSA", "2048", "2035-12-31",
+                      "CN=Subject A, O=Organisation A, C=UK", "2034-01-15" },
+                    { "TRUST_CERT", null, "NOT_EXPIRED", "trustedcert", "RSA", "4096", "2026-06-30",
                       "CN=Subject A, OU=Organizational Unit A, O=Organisation A, C=UK", "2024-01-10" },
-                    { "㊙", "✅", "\uD83D\uDD12", "secretkey", "AES", "256", "-", "CN=A", "2024-01-20" }
+                    { "KEY", true, null, "secretkey", "AES", "256", "-", "CN=A", "2024-01-20" }
             };
 
-            JKseTable table = new JKseTable(data, columnNames);
+            JTable table = new JTable(data, columnNames);
             table.setShowGrid(false);
             table.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
             table.getTableHeader().setReorderingAllowed(false);
             table.setRowHeight(Math.max(18, table.getRowHeight()));
-            table.setColumnsToIconSize(0, 1, 2);
+            setColumnsToIconSize(table, 0, 1, 2);
 
             KeyStoreTableColumns keyStoreTableColumns = new KeyStoreTableColumns();
 
-
+            addCustomRenderers(table, keyStoreTableColumns);
             new TableColumnAdjuster(table, keyStoreTableColumns).adjustColumns();
 
             JScrollPane scrollPane = new JScrollPane(table);
@@ -117,7 +118,7 @@ public class JKseTable extends ToolTipTable {
 
             frame.add(scrollPane, BorderLayout.CENTER);
 
-            JLabel statusLabel = new JLabel("JKseTable");
+            JLabel statusLabel = new JLabel("KseTable");
             statusLabel.setBorder(new EmptyBorder(5, 5, 5, 5));
             frame.add(statusLabel, BorderLayout.SOUTH);
 


### PR DESCRIPTION
The original intent of JKseTable was to automatically fix the table row height on high-DPI displays. A few years later, it was updated to include some utility methods. Now that the JDK defect is fixed in the minimum version of Java supported by KSE, and the fact that not all dialogs were using JKseTable, though the majority were, JKseTable can be retired.

This PR moves the utility methods of JKseTable into a new utility class called TableUtil and removes JKseTable. All dialogs are updated to use ToolTipTable.