### PR TITLE
Standarize the canceling/closing of dialog windows with a Cancel button.

### DIFF
--- a/kse/src/main/java/org/kse/gui/datetime/DDateTimeChooser.java
+++ b/kse/src/main/java/org/kse/gui/datetime/DDateTimeChooser.java
@@ -34,17 +34,21 @@ import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dialog;
 import java.awt.Insets;
+import java.awt.event.ActionEvent;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.ResourceBundle;
 
+import javax.swing.AbstractAction;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -310,6 +314,22 @@ public class DDateTimeChooser extends JEscDialog {
             @Override
             public void keyPressed(KeyEvent evt) {
                 calendarKeyboardNavigation(evt);
+            }
+        });
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DCheckUpdate.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DCheckUpdate.java
@@ -103,7 +103,8 @@ public class DCheckUpdate extends JEscDialog {
 
         jbCancel = new JButton(res.getString("DCheckUpdate.jbCancel.text"));
         jbCancel.addActionListener(evt -> cancelPressed());
-        jbCancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Need to use WHEN_FOCUSED since the cancel button will always have focus.
+        jbCancel.getInputMap(JComponent.WHEN_FOCUSED)
                 .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CANCEL_KEY);
         jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
@@ -123,10 +124,7 @@ public class DCheckUpdate extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                if ((checker != null) && (checker.isAlive())) {
-                    checker.interrupt();
-                }
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DExamineSsl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DExamineSsl.java
@@ -167,7 +167,7 @@ public class DExamineSsl extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DExaminingSsl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DExaminingSsl.java
@@ -124,7 +124,8 @@ public class DExaminingSsl extends JEscDialog {
 
         jbCancel = new JButton(res.getString("DExaminingSsl.jbCancel.text"));
         jbCancel.addActionListener(evt -> cancelPressed());
-        jbCancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Need to use WHEN_FOCUSED since the cancel button will always have focus.
+        jbCancel.getInputMap(JComponent.WHEN_FOCUSED)
                 .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CANCEL_KEY);
         jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
@@ -144,10 +145,7 @@ public class DExaminingSsl extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                if ((examiner != null) && (examiner.isAlive())) {
-                    examiner.interrupt();
-                }
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DExportCsv.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DExportCsv.java
@@ -145,7 +145,7 @@ public class DExportCsv extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DFindKeyStoreEntry.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DFindKeyStoreEntry.java
@@ -110,7 +110,7 @@ public class DFindKeyStoreEntry extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateCsr.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateCsr.java
@@ -259,7 +259,7 @@ public class DGenerateCsr extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateDHParameters.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateDHParameters.java
@@ -135,7 +135,7 @@ public class DGenerateDHParameters extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPair.java
@@ -232,7 +232,7 @@ public class DGenerateKeyPair extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPairCert.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPairCert.java
@@ -292,7 +292,7 @@ public class DGenerateKeyPairCert extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateSecretKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateSecretKey.java
@@ -134,7 +134,7 @@ public class DGenerateSecretKey extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGeneratingDHParameters.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGeneratingDHParameters.java
@@ -93,7 +93,6 @@ public class DGeneratingDHParameters extends JEscDialog {
      * Initializes the dialogue panel and associated elements
      */
     private void initComponents() {
-        // TODO Generate DH Parameters icon
         jlGenDHParameters = new JLabel(res.getString("DGeneratingDHParameters.jlGenDHParameters.text"));
         ImageIcon icon = new ImageIcon(getClass().getResource("images/genkp.png"));
         jlGenDHParameters.setIcon(icon);
@@ -103,7 +102,8 @@ public class DGeneratingDHParameters extends JEscDialog {
 
         jbCancel = new JButton(res.getString("DGeneratingDHParameters.jbCancel.text"));
         jbCancel.addActionListener(evt -> cancelPressed());
-        jbCancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Need to use WHEN_FOCUSED since the cancel button will always have focus.
+        jbCancel.getInputMap(JComponent.WHEN_FOCUSED)
                 .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CANCEL_KEY);
         jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
@@ -123,10 +123,7 @@ public class DGeneratingDHParameters extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                if ((generator != null) && (generator.isAlive())) {
-                    generator.interrupt();
-                }
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGeneratingKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGeneratingKeyPair.java
@@ -139,7 +139,8 @@ public class DGeneratingKeyPair extends JEscDialog {
 
         jbCancel = new JButton(res.getString("DGeneratingKeyPair.jbCancel.text"));
         jbCancel.addActionListener(evt -> cancelPressed());
-        jbCancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Need to use WHEN_FOCUSED since the cancel button will always have focus.
+        jbCancel.getInputMap(JComponent.WHEN_FOCUSED)
                 .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CANCEL_KEY);
         jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
@@ -159,10 +160,7 @@ public class DGeneratingKeyPair extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                if ((generator != null) && (generator.isAlive())) {
-                    generator.interrupt();
-                }
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DGetAlias.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGetAlias.java
@@ -140,7 +140,7 @@ public class DGetAlias extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DNewKeyStoreType.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DNewKeyStoreType.java
@@ -148,7 +148,7 @@ public class DNewKeyStoreType extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DOpenPkcs11KeyStore.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DOpenPkcs11KeyStore.java
@@ -76,7 +76,7 @@ public class DOpenPkcs11KeyStore extends JEscDialog {
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
 
     private transient KsePreferences preferences = PreferencesManager.getPreferences();
-    public static final int MAX_LIST_SIZE = 10;
+    private static final int MAX_LIST_SIZE = 10;
 
     private static final String CANCEL_KEY = "CANCEL_KEY";
 
@@ -202,7 +202,7 @@ public class DOpenPkcs11KeyStore extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DStorePassphrase.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DStorePassphrase.java
@@ -146,7 +146,7 @@ public class DStorePassphrase extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DVerifyCertificate.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DVerifyCertificate.java
@@ -249,7 +249,7 @@ public class DVerifyCertificate extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
         setTitle(MessageFormat.format(res.getString("DVerifyCertificate.Title"), certificateAlias));

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPassword.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPassword.java
@@ -156,7 +156,7 @@ public class DViewPassword extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewSecretKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewSecretKey.java
@@ -47,13 +47,12 @@ import javax.swing.SwingUtilities;
 
 import org.bouncycastle.util.encoders.DecoderException;
 import org.bouncycastle.util.encoders.Hex;
-import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
 import org.kse.crypto.secretkey.SecretKeyType;
 import org.kse.crypto.secretkey.SecretKeyUtil;
-import org.kse.gui.components.JEscDialog;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.components.JEscDialog;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.io.HexUtil;
 
@@ -109,10 +108,8 @@ public class DViewSecretKey extends JEscDialog {
      * @param modality  Dialog modality
      * @param secretKey Secret key to display
      * @param editable  Secret key can be edited/replaced
-     * @throws CryptoException A problem was encountered getting the secret key's details
      */
-    public DViewSecretKey(JDialog parent, String title, ModalityType modality, SecretKey secretKey, boolean editable)
-            throws CryptoException {
+    public DViewSecretKey(JDialog parent, String title, ModalityType modality, SecretKey secretKey, boolean editable) {
         super(parent, title, modality);
         this.secretKey = secretKey;
         this.editable = editable;
@@ -200,7 +197,7 @@ public class DViewSecretKey extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 
@@ -265,10 +262,18 @@ public class DViewSecretKey extends JEscDialog {
         closeDialog();
     }
 
+    /**
+     *
+     * @return True if the secret key has changed.
+     */
     public boolean keyHasChanged() {
         return keyHasChanged;
     }
 
+    /**
+     *
+     * @return The secret key.
+     */
     public SecretKey getSecretKey() {
         return secretKey;
     }

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensionType.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensionType.java
@@ -177,7 +177,7 @@ public class DAddExtensionType extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
@@ -425,7 +425,7 @@ public class DAddExtensions extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityInformationAccess.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityInformationAccess.java
@@ -155,7 +155,7 @@ public class DAuthorityInformationAccess extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityKeyIdentifier.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityKeyIdentifier.java
@@ -220,7 +220,7 @@ public class DAuthorityKeyIdentifier extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DBasicConstraints.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DBasicConstraints.java
@@ -146,7 +146,7 @@ public class DBasicConstraints extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DCertificatePolicies.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DCertificatePolicies.java
@@ -153,7 +153,7 @@ public class DCertificatePolicies extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DCrlDistributionPoints.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DCrlDistributionPoints.java
@@ -127,7 +127,7 @@ public class DCrlDistributionPoints extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DCustomExtKeyUsage.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DCustomExtKeyUsage.java
@@ -136,7 +136,7 @@ public class DCustomExtKeyUsage extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DExtendedKeyUsage.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DExtendedKeyUsage.java
@@ -243,7 +243,7 @@ public class DExtendedKeyUsage extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DInhibitAnyPolicy.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DInhibitAnyPolicy.java
@@ -139,7 +139,7 @@ public class DInhibitAnyPolicy extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DIssuerAlternativeName.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DIssuerAlternativeName.java
@@ -149,7 +149,7 @@ public class DIssuerAlternativeName extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DKeyUsage.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DKeyUsage.java
@@ -194,7 +194,7 @@ public class DKeyUsage extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DNameConstraints.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DNameConstraints.java
@@ -176,7 +176,7 @@ public class DNameConstraints extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DPolicyConstraints.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DPolicyConstraints.java
@@ -175,7 +175,7 @@ public class DPolicyConstraints extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DPolicyMappings.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DPolicyMappings.java
@@ -149,7 +149,7 @@ public class DPolicyMappings extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DPrivateKeyUsagePeriod.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DPrivateKeyUsagePeriod.java
@@ -185,7 +185,7 @@ public class DPrivateKeyUsagePeriod extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DSelectStandardExtensionTemplate.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DSelectStandardExtensionTemplate.java
@@ -177,7 +177,7 @@ public class DSelectStandardExtensionTemplate extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectAlternativeName.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectAlternativeName.java
@@ -149,7 +149,7 @@ public class DSubjectAlternativeName extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectInformationAccess.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectInformationAccess.java
@@ -151,7 +151,7 @@ public class DSubjectInformationAccess extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectKeyIdentifier.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DSubjectKeyIdentifier.java
@@ -136,7 +136,7 @@ public class DSubjectKeyIdentifier extends DExtension {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportCertificates.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportCertificates.java
@@ -289,7 +289,7 @@ public class DExportCertificates extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportCrl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportCrl.java
@@ -161,7 +161,7 @@ public class DExportCrl extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportKeyPair.java
@@ -222,7 +222,7 @@ public class DExportKeyPair extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyJwk.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyJwk.java
@@ -122,7 +122,7 @@ public class DExportPrivateKeyJwk extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyOpenSsl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyOpenSsl.java
@@ -262,7 +262,7 @@ public class DExportPrivateKeyOpenSsl extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyPkcs8.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyPkcs8.java
@@ -253,7 +253,7 @@ public class DExportPrivateKeyPkcs8 extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyPvk.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyPvk.java
@@ -336,7 +336,7 @@ public class DExportPrivateKeyPvk extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyType.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPrivateKeyType.java
@@ -169,7 +169,7 @@ public class DExportPrivateKeyType extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPublicKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DExportPublicKey.java
@@ -196,7 +196,7 @@ public class DExportPublicKey extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
@@ -275,7 +275,7 @@ public class DImportKeyPair extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 
@@ -331,8 +331,7 @@ public class DImportKeyPair extends JEscDialog {
         }
     }
 
-    private void detectFileType(File chosenFile)
-    {
+    private void detectFileType(File chosenFile) {
         try {
             fileType = CryptoFileUtil.detectFileType(chosenFile);
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DCrlReason.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DCrlReason.java
@@ -23,12 +23,16 @@ package org.kse.gui.dialogs.sign;
 import java.awt.Container;
 import java.awt.Dialog;
 import java.awt.HeadlessException;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.security.cert.CRLReason;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.ResourceBundle;
 
+import javax.swing.AbstractAction;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -182,6 +186,22 @@ public class DCrlReason extends JEscDialog {
 
         jbOK.addActionListener(evt -> okPressed());
         jbCancel.addActionListener(evt -> cancelPressed());
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
+            }
+        });
 
         populate();
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DCustomClaim.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DCustomClaim.java
@@ -22,9 +22,13 @@ package org.kse.gui.dialogs.sign;
 
 import java.awt.Container;
 import java.awt.Dialog;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.util.ResourceBundle;
 
+import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JFrame;
@@ -92,6 +96,22 @@ public class DCustomClaim extends JEscDialog {
 
         jbOK.addActionListener(evt -> okPressed());
         jbCancel.addActionListener(evt -> cancelPressed());
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
+            }
+        });
 
         populateFields();
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
@@ -26,6 +26,8 @@ import java.awt.Dimension;
 import java.awt.HeadlessException;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.security.cert.X509Certificate;
 import java.util.ResourceBundle;
 
@@ -138,6 +140,22 @@ public class DListCertificatesKS extends JEscDialog {
 
         jbOK.addActionListener(evt -> okPressed());
         jbCancel.addActionListener(evt -> cancelPressed());
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
+            }
+        });
 
         populate();
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCrl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCrl.java
@@ -23,7 +23,10 @@ package org.kse.gui.dialogs.sign;
 import java.awt.Container;
 import java.awt.Dialog;
 import java.awt.HeadlessException;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.PrivateKey;
@@ -34,6 +37,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.concurrent.TimeUnit;
 
+import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -211,6 +215,22 @@ public class DSignCrl extends JEscDialog {
                 jdtEffectiveDate.setDateTime(startDate);
             }
             jdtNextUpdate.setDateTime(jvpValidityPeriod.getValidityEnd(startDate));
+        });
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
+            }
         });
 
         setResizable(false);

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
@@ -436,7 +436,7 @@ public class DSignCsr extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignFile.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignFile.java
@@ -257,7 +257,7 @@ public class DSignFile extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJar.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJar.java
@@ -276,7 +276,7 @@ public class DSignJar extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJarSigning.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJarSigning.java
@@ -80,7 +80,7 @@ public class DSignJarSigning extends JEscDialog {
     private String tsaUrl;
     private Provider provider;
 
-    private Thread generator;
+    private Thread signerThread;
     private boolean successStatus = true;
 
     /**
@@ -117,7 +117,8 @@ public class DSignJarSigning extends JEscDialog {
 
         jbCancel = new JButton(res.getString("DSignJarSigning.jbCancel.text"));
         jbCancel.addActionListener(evt -> cancelPressed());
-        jbCancel.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+        // Need to use WHEN_FOCUSED since the cancel button will always have focus.
+        jbCancel.getInputMap(JComponent.WHEN_FOCUSED)
                 .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), CANCEL_KEY);
         jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
             private static final long serialVersionUID = 1L;
@@ -137,10 +138,7 @@ public class DSignJarSigning extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                if ((generator != null) && (generator.isAlive())) {
-                    generator.interrupt();
-                }
-                closeDialog();
+                cancelPressed();
             }
         });
 
@@ -154,9 +152,9 @@ public class DSignJarSigning extends JEscDialog {
      * Start signing in a separate thread.
      */
     public void startDSignJarSigning() {
-        generator = new Thread(new signJars());
-        generator.setPriority(Thread.MIN_PRIORITY);
-        generator.start();
+        signerThread = new Thread(new signJars());
+        signerThread.setPriority(Thread.MIN_PRIORITY);
+        signerThread.start();
     }
 
     /**
@@ -172,8 +170,8 @@ public class DSignJarSigning extends JEscDialog {
      * Calls the close dialogue, Sets the success value to false
      */
     private void cancelPressed() {
-        if ((generator != null) && (generator.isAlive())) {
-            generator.interrupt();
+        if ((signerThread != null) && (signerThread.isAlive())) {
+            signerThread.interrupt();
         }
         successStatus = false;
         closeDialog();

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJwt.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJwt.java
@@ -22,7 +22,10 @@ package org.kse.gui.dialogs.sign;
 
 import java.awt.Container;
 import java.awt.Dialog;
+import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.util.Calendar;
@@ -31,6 +34,7 @@ import java.util.List;
 import java.util.ResourceBundle;
 import java.util.UUID;
 
+import javax.swing.AbstractAction;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -213,6 +217,22 @@ public class DSignJwt extends JEscDialog {
         jbGenId.addActionListener(evt -> genIdPressed());
         jbOK.addActionListener(evt -> okPressed());
         jbCancel.addActionListener(evt -> cancelPressed());
+
+        jbCancel.getActionMap().put(CANCEL_KEY, new AbstractAction() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void actionPerformed(ActionEvent evt) {
+                cancelPressed();
+            }
+        });
+
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent evt) {
+                cancelPressed();
+            }
+        });
 
         setResizable(false);
 

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignMidlet.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignMidlet.java
@@ -258,7 +258,7 @@ public class DSignMidlet extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/password/DChangePassword.java
+++ b/kse/src/main/java/org/kse/gui/password/DChangePassword.java
@@ -190,7 +190,7 @@ public class DChangePassword extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/password/DGetNewPassword.java
+++ b/kse/src/main/java/org/kse/gui/password/DGetNewPassword.java
@@ -165,7 +165,7 @@ public class DGetNewPassword extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/password/DGetPassword.java
+++ b/kse/src/main/java/org/kse/gui/password/DGetPassword.java
@@ -122,7 +122,7 @@ public class DGetPassword extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/passwordmanager/DInitPasswordManager.java
+++ b/kse/src/main/java/org/kse/gui/passwordmanager/DInitPasswordManager.java
@@ -119,7 +119,7 @@ public class DInitPasswordManager extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 

--- a/kse/src/main/java/org/kse/gui/passwordmanager/DUnlockPasswordManager.java
+++ b/kse/src/main/java/org/kse/gui/passwordmanager/DUnlockPasswordManager.java
@@ -117,7 +117,7 @@ public class DUnlockPasswordManager extends JEscDialog {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                cancelPressed();
             }
         });
 


### PR DESCRIPTION
Fixes #660.

* Added the missing action for CANCEL_KEY for classes with an input mapping for it.
* Update WindowAdapter to call the cancel action when closing the window. Fixes unnecessary errors for DSignJar, DSignFile, and others that depend on state set by the cancel button.
* Fixed use of Escape key for progress dialogs. The progress dialogs Escape key binding was never active. For DGeneratingDHParameters, pressing Escape caused the action to display an error rather than cancelling.

DPkcs12Info is the only dialog with a Cancel button that is not updated. Closing the window or pressing the Escape key will open the key store rather than cancelling. This appears to be the intended behavior. If not, let me know, and I'll update it.