### PR TITLE
Use import file type for private key type.

### DIFF
--- a/kse/src/main/java/org/kse/gui/dialogs/DViewKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewKeyPair.java
@@ -26,6 +26,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 import javax.swing.JButton;
@@ -156,7 +157,7 @@ public class DViewKeyPair extends JEscDialog {
     private void privateKeyDetailsPressed() {
         try {
             DViewPrivateKey dViewPrivateKey = new DViewPrivateKey(this, res.getString(
-                    "DViewKeyPair.ViewPrivateKeyDetails.Title"), privateKey);
+                    "DViewKeyPair.ViewPrivateKeyDetails.Title"), privateKey, Optional.empty());
             dViewPrivateKey.setLocationRelativeTo(this);
             dViewPrivateKey.setVisible(true);
         } catch (CryptoException ex) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
@@ -106,7 +106,10 @@ public class DViewPrivateKey extends JEscDialog {
      *
      * @param parent     Parent frame
      * @param title      The dialog title
+     * @param alias      The entry alias. Used for prepopulating the export file name.
      * @param privateKey Private key to display
+     * @param preferences The preferences for exporting.
+     * @param format     The private key file format. If not provided, the internal JVM private key format.
      * @throws CryptoException A problem was encountered getting the private key's details
      */
     public DViewPrivateKey(JFrame parent, String title, String alias, PrivateKey privateKey, KsePreferences preferences,
@@ -125,12 +128,14 @@ public class DViewPrivateKey extends JEscDialog {
      * @param parent     Parent dialog
      * @param title      The dialog title
      * @param privateKey Private key to display
+     * @param format     The private key file format. If not provided, the internal JVM private key format.
      * @throws CryptoException A problem was encountered getting the private key's details
      */
-    public DViewPrivateKey(JDialog parent, String title, PrivateKey privateKey) throws CryptoException {
+    public DViewPrivateKey(JDialog parent, String title, PrivateKey privateKey, Optional<PrivateKeyFormat> format)
+            throws CryptoException {
         super(parent, title, ModalityType.DOCUMENT_MODAL);
         this.privateKey = privateKey;
-        this.format = Optional.empty();
+        this.format = format;
         initComponents();
         jbExport.setVisible(false);
     }

--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
@@ -39,6 +39,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Optional;
 import java.util.ResourceBundle;
 
 import javax.swing.AbstractAction;
@@ -68,6 +69,7 @@ import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.crypto.privatekey.MsPvkUtil;
 import org.kse.crypto.privatekey.OpenSslPvkUtil;
 import org.kse.crypto.privatekey.Pkcs8Util;
+import org.kse.crypto.privatekey.PrivateKeyFormat;
 import org.kse.crypto.privatekey.PrivateKeyPbeNotSupportedException;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CurrentDirectory;
@@ -398,8 +400,9 @@ public class DImportKeyPair extends JEscDialog {
                             res.getString("DImportKeyPair.ViewKeyPairDetails.Title"), path), privateKey,
                             certificateChain);
                 } else {
-                    dViewDetails = new DViewPrivateKey(this, MessageFormat.format(
-                            res.getString("DImportKeyPair.ViewPrivateKeyDetails.Title"), path), privateKey);
+                    dViewDetails = new DViewPrivateKey(this,
+                            MessageFormat.format(res.getString("DImportKeyPair.ViewPrivateKeyDetails.Title"), path),
+                            privateKey, Optional.ofNullable(getPrivateKeyFormat()));
                 }
                 dViewDetails.setLocationRelativeTo(this);
                 dViewDetails.setVisible(true);
@@ -407,6 +410,29 @@ public class DImportKeyPair extends JEscDialog {
         } catch (CryptoException ex) {
             DError.displayError(this, ex);
         }
+    }
+
+    private PrivateKeyFormat getPrivateKeyFormat() {
+        PrivateKeyFormat format;
+        switch (fileType) {
+            case ENC_PKCS8_PVK:
+            case UNENC_PKCS8_PVK:
+               format = PrivateKeyFormat.PKCS8;
+               break;
+            case ENC_OPENSSL_PVK:
+            case UNENC_OPENSSL_PVK:
+                format = PrivateKeyFormat.PKCS1;
+                break;
+            case ENC_MS_PVK:
+            case UNENC_MS_PVK:
+                format = PrivateKeyFormat.MSPVK;
+                break;
+            default:
+                // Ignore the file types since detectFileType filters out unsupported file types.
+                format = null;
+                break;
+        }
+        return format;
     }
 
     private PrivateKey loadPrivateKey() {


### PR DESCRIPTION
Enhances PR #658 by displaying PKCS#8, PKCS#1, or MS PVK when clicking on the private key Details button when importing a key pair. This aligns the Import Key Pair action with the Examine File action so that they are consistent.