### PR TITLE
✏️ improve 'colon' (`:`) management (on `X509Ext.java`)

### DIFF
--- a/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
@@ -593,7 +593,7 @@ public class X509Ext {
 
                 String attributeValueStr = getAttributeValueString(attributeType, attributeValue);
 
-                sb.append(MessageFormat.format("{0}: {1}", attributeTypeStr, attributeValueStr));
+                sb.append(MessageFormat.format(res.getString("genericTypeValueFormat"), attributeTypeStr, attributeValueStr));
                 sb.append(NEWLINE);
             }
         }
@@ -1734,7 +1734,7 @@ public class X509Ext {
 
                 sb.append(baseIndent);
                 sb.append(INDENT.toString(2));
-                sb.append(MessageFormat.format("{0}={1}", attributeTypeStr, attributeValueStr));
+                sb.append(MessageFormat.format(res.getString("genericTypeValueFormat"), attributeTypeStr, attributeValueStr));
                 sb.append(NEWLINE);
             }
         }
@@ -2778,7 +2778,7 @@ public class X509Ext {
 
                 String attributeValueStr = getAttributeValueString(attributeId, attributeValue);
 
-                sb.append(MessageFormat.format("{0}={1}", attributeId.getId(), attributeValueStr));
+                sb.append(MessageFormat.format(res.getString("genericTypeValueFormat"), attributeId.getId(), attributeValueStr));
                 sb.append(NEWLINE);
             }
         }

--- a/kse/src/main/resources/org/kse/crypto/x509/resources.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources.properties
@@ -618,6 +618,8 @@ VeriSignUnknown = VeriSign Unknown
 
 custom = > Custom Extension <
 
+genericTypeValueFormat = {0}: {1}
+
 unknown = (Unknown OID)
 
 SignedCertificateTimestamp = Signed Certificate Timestamp [{0}]:

--- a/kse/src/main/resources/org/kse/crypto/x509/resources_de.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources_de.properties
@@ -601,5 +601,7 @@ VeriSignUnknown = VeriSign Unbekannt
 
 custom = > Custom Erweiterung <
 
+genericTypeValueFormat = {0}: {1}
+
 unknown = (Unbekannte OID)
 

--- a/kse/src/main/resources/org/kse/crypto/x509/resources_es.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources_es.properties
@@ -338,6 +338,7 @@ VeriSignSerialNumberRollover=Cambio de Número de Serie de VeriSign
 VeriSignTokenType=Tipo de Token de VeriSign
 VeriSignUnknown=VeriSign Desconocido
 custom=> Extensión Personalizada <
+genericTypeValueFormat={0}: {1}
 unknown=(OID Desconocido)
 SignedCertificateTimestamp=Marca de tiempo de certificado firmado [{0}]:
 SCTVersion=Versión: {0}

--- a/kse/src/main/resources/org/kse/crypto/x509/resources_fr.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources_fr.properties
@@ -352,4 +352,5 @@ VeriSignSerialNumberRollover = VeriSign Serial Number Rollover
 VeriSignTokenType = VeriSign Token Type
 VeriSignUnknown = VeriSign Unknown
 custom = > Extension personnalisée <
+genericTypeValueFormat = {0} : {1}
 unknown = (OID inconnu)


### PR DESCRIPTION
Hello KSE Team, @kaikramer 

To continue:
- #672

Here is a PR in order to:
- [x] ✏️ fix 'colon'  (`:`) management on `X509Ext.java`
- [x] 💥 Change some `{0}={1}` to `{0}: {1}` (and  now depends of res.)
_Especially for French language_

Ref.:
- https://en.wikipedia.org/wiki/Colon_(punctuation)
- https://fr.wikipedia.org/wiki/Deux-points
- https://de.wikipedia.org/wiki/Doppelpunkt

Regards,
Th.

---
:copilot: 
This pull request standardizes the formatting of attribute type-value pairs in X.509 extension string representations by introducing a new resource string for this format and updating usages throughout the codebase. The change ensures consistent localization and formatting across different languages.

Localization improvements:

* Added a new resource string `genericTypeValueFormat` to all relevant localization files (`resources.properties`, `resources_de.properties`, `resources_es.properties`, `resources_fr.properties`) to define a standard format for displaying attribute type-value pairs. [[1]](diffhunk://#diff-1398f5b79d078076a57cf722c806c7061dbf4a7e21736ed9385f58c99cb70a40R621-R622) [[2]](diffhunk://#diff-6c2be79a74cb67c8c02cbd57cbca956d65b43e6cfa948e034aa7120ff0b6c82bR604-R605) [[3]](diffhunk://#diff-2aaffab233d9509e59bd440c2eea9516c77fe97e3bd40550afdfa83af57c4133R341) [[4]](diffhunk://#diff-545bc1a4313a9928dbcd337a0e81dc0628aa784a383f94e85706695b85d95bd3R355)

Formatting consistency in code:

* Updated all usages of attribute type-value formatting in `X509Ext.java` to use the new `genericTypeValueFormat` resource string, replacing hardcoded format strings for subject directory attributes, distribution point names, and VeriSign non-verified attributes. [[1]](diffhunk://#diff-f53d5c3daaa53f8df69a2be3dff8ec9d424ad67ba8f90332707384cd5e170866L596-R596) [[2]](diffhunk://#diff-f53d5c3daaa53f8df69a2be3dff8ec9d424ad67ba8f90332707384cd5e170866L1737-R1737) [[3]](diffhunk://#diff-f53d5c3daaa53f8df69a2be3dff8ec9d424ad67ba8f90332707384cd5e170866L2781-R2781)

---
