### PR TITLE
Implement case-sensitive alias by key store type.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
+++ b/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
@@ -33,7 +33,6 @@ import java.text.MessageFormat;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -156,6 +155,9 @@ public class KeyStoreTableModel extends ToolTipTableModel {
 
     /**
      * Construct a new KeyStoreTableModel with a variable layout.
+     *
+     * @param keyStoreTableColumns The key store table columns to display from preferences.
+     * @param expiryWarnDays       The number of days for expiration warning from preferences.
      */
     public KeyStoreTableModel(KeyStoreTableColumns keyStoreTableColumns, int expiryWarnDays) {
         super(res, COLUMN_TOOL_TIPS);
@@ -182,7 +184,7 @@ public class KeyStoreTableModel extends ToolTipTableModel {
 
         Enumeration<String> aliases = keyStore.aliases();
 
-        TreeMap<String, String> sortedAliases = new TreeMap<>(new AliasComparator());
+        TreeMap<String, String> sortedAliases = new TreeMap<>(type.getAliasComparator());
 
         while (aliases.hasMoreElements()) {
             String alias = aliases.nextElement();
@@ -745,14 +747,7 @@ public class KeyStoreTableModel extends ToolTipTableModel {
         return false;
     }
 
-    public KeyStoreHistory getHistory() {
+    KeyStoreHistory getHistory() {
         return history;
-    }
-
-    private class AliasComparator implements Comparator<String> {
-        @Override
-        public int compare(String name1, String name2) {
-            return name1.compareToIgnoreCase(name2);
-        }
     }
 }

--- a/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
@@ -177,13 +177,14 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             DGetAlias dGetAlias = new DGetAlias(frame,
                                                 res.getString("GenerateKeyPairAction.NewKeyPairEntryAlias.Title"),
                                                 X509CertUtil.getCertificateAlias(certificate));
             dGetAlias.setLocationRelativeTo(frame);
             dGetAlias.setVisible(true);
-            alias = dGetAlias.getAlias();
+            alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
             if (alias == null) {
                 return "";

--- a/kse/src/main/java/org/kse/gui/actions/GenerateSecretKeyAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/GenerateSecretKeyAction.java
@@ -108,13 +108,14 @@ public class GenerateSecretKeyAction extends KeyStoreExplorerAction implements H
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             DGetAlias dGetAlias = new DGetAlias(frame,
                                                 res.getString("GenerateSecretKeyAction.NewSecretKeyEntryAlias.Title"),
                                                 null);
             dGetAlias.setLocationRelativeTo(frame);
             dGetAlias.setVisible(true);
-            String alias = dGetAlias.getAlias();
+            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
             if (alias == null) {
                 return;
@@ -130,8 +131,6 @@ public class GenerateSecretKeyAction extends KeyStoreExplorerAction implements H
                     return;
                 }
             }
-
-            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             Password password = getNewEntryPassword(keyStoreType,
                     res.getString("GenerateSecretKeyAction.NewSecretKeyEntryPassword.Title"), currentState, newState);

--- a/kse/src/main/java/org/kse/gui/actions/ImportKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ImportKeyPairAction.java
@@ -91,13 +91,14 @@ public class ImportKeyPairAction extends KeyStoreExplorerAction implements Histo
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             DGetAlias dGetAlias = new DGetAlias(frame, res.getString("ImportKeyPairAction.NewKeyPairEntryAlias.Title"),
                                                 X509CertUtil.getCertificateAlias(certs[0]));
 
             dGetAlias.setLocationRelativeTo(frame);
             dGetAlias.setVisible(true);
-            String alias = dGetAlias.getAlias();
+            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
             if (alias == null) {
                 return;
@@ -113,8 +114,6 @@ public class ImportKeyPairAction extends KeyStoreExplorerAction implements Histo
                     return;
                 }
             }
-
-            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             Password password = getNewEntryPassword(keyStoreType,
                     res.getString("ImportKeyPairAction.NewKeyPairEntryPassword.Title"), currentState, newState);

--- a/kse/src/main/java/org/kse/gui/actions/ImportTrustedCertificateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ImportTrustedCertificateAction.java
@@ -31,6 +31,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
+import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CurrentDirectory;
 import org.kse.gui.FileChooserFactory;
@@ -107,6 +108,7 @@ public class ImportTrustedCertificateAction extends AuthorityCertificatesAction 
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             // use either cert that was passed to c-tor or the one from file selection dialog
             X509Certificate trustCert = null;
@@ -190,7 +192,7 @@ public class ImportTrustedCertificateAction extends AuthorityCertificatesAction 
                                                 X509CertUtil.getCertificateAlias(trustCert));
             dGetAlias.setLocationRelativeTo(frame);
             dGetAlias.setVisible(true);
-            String alias = dGetAlias.getAlias();
+            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
             if (alias == null) {
                 return;

--- a/kse/src/main/java/org/kse/gui/actions/RenameKeyAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameKeyAction.java
@@ -30,6 +30,7 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
 import org.kse.gui.passwordmanager.Password;
+import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.gui.KseFrame;
 import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.error.DError;
@@ -91,6 +92,7 @@ public class RenameKeyAction extends KeyStoreExplorerAction implements HistoryAc
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             Key key = keyStore.getKey(alias, password.toCharArray());
 
@@ -103,7 +105,7 @@ public class RenameKeyAction extends KeyStoreExplorerAction implements HistoryAc
                 return;
             }
 
-            if (newAlias.equalsIgnoreCase(alias)) {
+            if (keyStoreType.getAliasComparator().compare(alias, newAlias) == 0) {
                 JOptionPane.showMessageDialog(frame, MessageFormat.format(
                                                       res.getString("RenameKeyAction.RenameAliasIdentical.message"),
                                                       alias),

--- a/kse/src/main/java/org/kse/gui/actions/RenameKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameKeyPairAction.java
@@ -31,6 +31,7 @@ import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
 import org.kse.gui.passwordmanager.Password;
+import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
 import org.kse.gui.dialogs.DGetAlias;
@@ -93,6 +94,7 @@ public class RenameKeyPairAction extends KeyStoreExplorerAction implements Histo
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             Key privateKey = keyStore.getKey(alias, password.toCharArray());
 
@@ -108,7 +110,7 @@ public class RenameKeyPairAction extends KeyStoreExplorerAction implements Histo
                 return;
             }
 
-            if (newAlias.equalsIgnoreCase(alias)) {
+            if (keyStoreType.getAliasComparator().compare(alias, newAlias) == 0) {
                 JOptionPane.showMessageDialog(frame, MessageFormat.format(
                                                       res.getString("RenameKeyPairAction.RenameAliasIdentical" +
                                                                     ".message"), alias),

--- a/kse/src/main/java/org/kse/gui/actions/RenameTrustedCertificateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RenameTrustedCertificateAction.java
@@ -29,6 +29,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
+import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.gui.KseFrame;
 import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.error.DError;
@@ -82,6 +83,8 @@ public class RenameTrustedCertificateAction extends KeyStoreExplorerAction imple
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
+
             String alias = kseFrame.getSelectedEntryAlias();
 
             DGetAlias dGetAlias = new DGetAlias(frame,
@@ -95,7 +98,7 @@ public class RenameTrustedCertificateAction extends KeyStoreExplorerAction imple
                 return;
             }
 
-            if (newAlias.equalsIgnoreCase(alias)) {
+            if (keyStoreType.getAliasComparator().compare(alias, newAlias) == 0) {
                 JOptionPane.showMessageDialog(frame, MessageFormat.format(
                                                       res.getString("RenameTrustedCertificateAction" +
                                                                     ".RenameAliasIdentical.message"), alias),

--- a/kse/src/main/java/org/kse/gui/actions/StorePassphraseAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/StorePassphraseAction.java
@@ -108,13 +108,14 @@ public class StorePassphraseAction extends KeyStoreExplorerAction implements His
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             DGetAlias dGetAlias = new DGetAlias(frame,
                                                 res.getString("StorePassphraseAction.NewPassphraseEntryAlias.Title"),
                                                 null);
             dGetAlias.setLocationRelativeTo(frame);
             dGetAlias.setVisible(true);
-            String alias = dGetAlias.getAlias();
+            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
             if (alias == null) {
                 return;
@@ -130,8 +131,6 @@ public class StorePassphraseAction extends KeyStoreExplorerAction implements His
                     return;
                 }
             }
-
-            KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             Password password = getNewEntryPassword(keyStoreType,
                     res.getString("StorePassphraseAction.NewPassphraseEntryPassword.Title"), currentState, newState);

--- a/kse/src/main/java/org/kse/gui/dialogs/DGetAlias.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGetAlias.java
@@ -160,7 +160,7 @@ public class DGetAlias extends JEscDialog {
     }
 
     private boolean checkAlias() {
-        String alias = jtfAlias.getText().trim().toLowerCase();
+        String alias = jtfAlias.getText().trim();
 
         if (!alias.isEmpty()) {
             this.alias = alias;

--- a/kse/src/main/resources/org/kse/gui/actions/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/actions/resources.properties
@@ -28,6 +28,7 @@ ChangeTypeAction.ChangeFromPkcs12Password.message     = The current KeyStore typ
 ChangeTypeAction.ChangeKeyStoreType.Title             = Change KeyStore Type
 ChangeTypeAction.ChangeKeyStoreTypeSuccessful.message = Change KeyStore Type Successful.
 ChangeTypeAction.History.text                         = Change Type to {0}
+ChangeTypeAction.NotifyDuplicateAlias.message         = The new KeyStore type does not support case-sensitive aliases. The current KeyStore contains aliases that will be duplicate after conversion. The duplicate aliases will be renamed with a suffix.
 ChangeTypeAction.WarnNoChangeKey.message              = The KeyStore contains at least one Key entry.\nThese entries will be lost in the type change.\nDo you want to continue?
 ChangeTypeAction.WarnNoECC.message                    = The KeyStore contains at least one EC KeyPair entry.\nThe new KeyStore type does not support EC keys, \nso these entries will be lost in the type change.\nDo you want to continue?
 ChangeTypeAction.WarnUnsupportedKey.message           = The KeyStore contains at least one Key entry with an unsupported algorithm.\nThese entries will be lost in the type change.\nDo you want to continue?


### PR DESCRIPTION
This PR closes #10 by adding case-sensitive/case-insensitive support based on the key store type.

When converting from case-sensitive to case-insensitive, the following warning will be displayed if duplicate aliases will exist after the conversion:
<img width="644" height="295" alt="image" src="https://github.com/user-attachments/assets/01f90d96-c35a-4744-8ffe-e38d574789bc" />

After conversion:
<img width="508" height="273" alt="image" src="https://github.com/user-attachments/assets/48df1cf4-6eb0-4477-a7f8-455065e68b38" />

