### PR TITLE
Remove work arounds for Java versions less than 15.

### DIFF
--- a/kse/src/main/java/org/kse/crypto/keypair/KeyPairUtil.java
+++ b/kse/src/main/java/org/kse/crypto/keypair/KeyPairUtil.java
@@ -47,6 +47,7 @@ import java.security.interfaces.DSAParams;
 import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.EdECPrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.DSAPrivateKeySpec;
@@ -467,7 +468,7 @@ public final class KeyPairUtil {
                 PublicKey publicKey = kf.generatePublic(publicSpec);
                 keyPair = new KeyPair(publicKey, privateKey);
             }
-            if (EccUtil.isEdPrivateKey(privateKey)) {
+            if (privateKey instanceof EdECPrivateKey) {
                 EdDSAPrivateKey edPrivate = EccUtil.getEdPrivateKey(privateKey);
                 byte[] pubKeyBytes = edPrivate.getPublicKey().getEncoded();
                 KeyFactory kf = KeyFactory.getInstance(edPrivate.getAlgorithm(), KSE.BC);

--- a/kse/src/main/java/org/kse/crypto/signing/SignatureType.java
+++ b/kse/src/main/java/org/kse/crypto/signing/SignatureType.java
@@ -49,7 +49,6 @@ import org.bouncycastle.asn1.pkcs.RSASSAPSSparams;
 import org.bouncycastle.asn1.rosstandart.RosstandartObjectIdentifiers;
 import org.kse.crypto.digest.DigestType;
 import org.kse.crypto.ecc.EdDSACurves;
-import org.kse.version.JavaVersion;
 
 /**
  * Enumeration of Signature Types supported by the X509CertUtil class.
@@ -269,14 +268,10 @@ public enum SignatureType {
         signatureTypes.add(SHA384WITHRSAANDMGF1);
         signatureTypes.add(SHA512WITHRSAANDMGF1);
 
-        // SHA3 signatures cause problems when reading certificates with standard providers (e.g. in P12 keystore)
-        // because at least up to Java 15 there is no support for SHA3 signatures (see http://openjdk.java.net/jeps/287)
-        if (JavaVersion.getJreVersion().isAtLeast(JavaVersion.JRE_VERSION_17)) {
-            signatureTypes.add(SHA3_224WITHRSAANDMGF1);
-            signatureTypes.add(SHA3_256WITHRSAANDMGF1);
-            signatureTypes.add(SHA3_384WITHRSAANDMGF1);
-            signatureTypes.add(SHA3_512WITHRSAANDMGF1);
-        }
+        signatureTypes.add(SHA3_224WITHRSAANDMGF1);
+        signatureTypes.add(SHA3_256WITHRSAANDMGF1);
+        signatureTypes.add(SHA3_384WITHRSAANDMGF1);
+        signatureTypes.add(SHA3_512WITHRSAANDMGF1);
 
         return signatureTypes;
     }

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewAsymmetricKeyFields.java
@@ -36,6 +36,7 @@ import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.DSAPublicKey;
 import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.EdECPrivateKey;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
@@ -132,7 +133,7 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
             return MessageFormat.format(res.getString("DViewAsymmetricKeyFields.PrivateKey.title"), "EC");
         } else if (key instanceof EdDSAPublicKey) {
             return MessageFormat.format(res.getString("DViewAsymmetricKeyFields.PublicKey.title"), getEdAlg(key));
-        } else if (EccUtil.isEdPrivateKey(key)) {
+        } else if (key instanceof EdECPrivateKey) {
             return MessageFormat.format(res.getString("DViewAsymmetricKeyFields.PrivateKey.title"), getEdAlg(key));
         } else if (key instanceof MLDSAPublicKey) {
             return MessageFormat.format(res.getString("DViewAsymmetricKeyFields.PublicKey.title"), "ML-DSA");
@@ -239,7 +240,7 @@ public class DViewAsymmetricKeyFields extends JEscDialog {
             fields = getEcPrivateFields();
         } else if (key instanceof EdDSAPublicKey) {
             fields = getEdPubFields();
-        } else if (EccUtil.isEdPrivateKey(key)) {
+        } else if (key instanceof EdECPrivateKey) {
             fields = getEdPrivateFields();
         } else if (key instanceof MLDSAPublicKey) {
             fields = getMLDSAPublicFields();

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPrivateKey.java
@@ -33,6 +33,7 @@ import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.interfaces.DSAPrivateKey;
 import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.EdECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.MessageFormat;
 import java.util.Optional;
@@ -54,7 +55,6 @@ import org.bouncycastle.jcajce.interfaces.SLHDSAPrivateKey;
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
-import org.kse.crypto.ecc.EccUtil;
 import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.crypto.privatekey.PrivateKeyFormat;
 import org.kse.gui.CursorUtil;
@@ -311,7 +311,7 @@ public class DViewPrivateKey extends JEscDialog {
         jtaEncoded.setCaretPosition(0);
 
         jbFields.setEnabled((privateKey instanceof RSAPrivateKey) || (privateKey instanceof DSAPrivateKey)
-                || (privateKey instanceof ECPrivateKey) || (EccUtil.isEdPrivateKey(privateKey))
+                || (privateKey instanceof ECPrivateKey) || (privateKey instanceof EdECPrivateKey)
                 || (privateKey instanceof MLDSAPrivateKey) || (privateKey instanceof SLHDSAPrivateKey));
     }
 

--- a/kse/src/test/java/org/kse/crypto/ecc/EccUtilTest.java
+++ b/kse/src/test/java/org/kse/crypto/ecc/EccUtilTest.java
@@ -22,10 +22,8 @@ package org.kse.crypto.ecc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigInteger;
 import java.security.InvalidParameterException;
@@ -184,11 +182,4 @@ public class EccUtilTest extends CryptoTestsBase {
         assertThrows(InvalidParameterException.class, () -> EccUtil.detectEdDSACurve(ecKeyPair.getPublic()));
     }
 
-    @Test
-    void isEdPrivateKey() throws Exception {
-        KeyPair edKeyPair = KeyPairUtil.generateECKeyPair("Ed448", KSE.BC);
-        assertTrue(EccUtil.isEdPrivateKey(edKeyPair.getPrivate()));
-        assertFalse(EccUtil.isEdPrivateKey(edKeyPair.getPublic()));
-        assertFalse(EccUtil.isEdPrivateKey(KeyPairUtil.generateECKeyPair("secp384r1", KSE.BC).getPrivate()));
-    }
 }


### PR DESCRIPTION
This PR removes the workarounds for Java versions less than 15. I know you're getting ready to release the next version so you can wait to merge this if you want.

EdDSA private keys will always be an instance of EdECPrivateKey (JDK). EdDSA public keys will always be an instance of EdDSAPublicKey (BC) because certs are always converted using the BC provider and public keys go through the OpenSslPubUtil, which also uses the BC provider.
