### PR TITLE
Detect if a private key file has certs and treat it like a key pair file

### DIFF
--- a/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/importexport/DImportKeyPair.java
@@ -349,8 +349,39 @@ public class DImportKeyPair extends JEscDialog {
                 return;
             }
 
+            switch (fileType) {
+            case ENC_PKCS8_PVK:
+            case UNENC_PKCS8_PVK:
+            case ENC_OPENSSL_PVK:
+            case UNENC_OPENSSL_PVK:
+                // check for certs in the private key file
+                try {
+                    certificateChain = X509CertUtil.loadCertificates(Files.readAllBytes(chosenFile.toPath()));
+                } catch (CryptoException e) {
+                    // ignore since a failure likely means that there
+                    // are no certificates, which is ok.
+
+                    // Need to reset certificateChain in case the user chose a file that
+                    // had certificates, and then decided to choose a different file that
+                    // does not have certificates.
+                    certificateChain = null;
+                }
+                break;
+            default:
+                // PKCS #12 or MS PVK -- just reset the certificateChain
+
+                // Need to reset certificateChain in case the user chose a file that
+                // had certificates, and then decided to choose a different file that
+                // does not have certificates.
+                certificateChain = null;
+                break;
+            }
+
+            boolean isSelectCertificateFile = fileType != CryptoFileType.PKCS12_KS && (certificateChain == null
+                    || certificateChain.length == 0);
+
             setEnabledPassword(encrypted);
-            setEnabledCertificate(fileType != CryptoFileType.PKCS12_KS);
+            setEnabledCertificate(isSelectCertificateFile);
         } catch (FileNotFoundException | NoSuchFileException e) {
             JOptionPane.showMessageDialog(this,
                     MessageFormat.format(res.getString("DImportKeyPair.NoReadFile.message"),
@@ -394,7 +425,10 @@ public class DImportKeyPair extends JEscDialog {
 
             if (privateKey != null) {
                 JDialog dViewDetails;
-                if (fileType == CryptoFileType.PKCS12_KS) {
+                // This condition covers these cases:
+                // 1. The file type is PKCS #12
+                // 2. The file type is PEM with a certificate chain in it
+                if (!jtfCertificatePath.isEnabled() && certificateChain != null && certificateChain.length > 0) {
                     dViewDetails = new DViewKeyPair(this, MessageFormat.format(
                             res.getString("DImportKeyPair.ViewKeyPairDetails.Title"), path), privateKey,
                             certificateChain);


### PR DESCRIPTION
This PR is an enhancement to #191. It detects if a PEM encoded PKCS#8 or OpenSSL private key file contains a certificates, and it treats the PEM file as if it was a key pair.

This is a shortcut so that users do not have to choose the same file for both the private key and certificate files during import. This is just an update to the dialog so the private key must be first in the PEM file, like this:

-----BEGIN PRIVATE KEY -----
-----END PRIVATE KEY -----
-----BEGIN CERTIFICATE-----
-----END CERTIFICATE-----
…
-----BEGIN CERTIFICATE-----
-----END CERTIFICATE-----
