### PR TITLE
Add Description and Role X.500 attributes

### DIFF
--- a/kse/src/main/java/org/kse/crypto/x509/AttributeTypeType.java
+++ b/kse/src/main/java/org/kse/crypto/x509/AttributeTypeType.java
@@ -44,6 +44,9 @@ public enum AttributeTypeType {
     MAIL("0.9.2342.19200300.100.1.3", "MailAttributeType"),
     DOMAIN_COMPONENT("0.9.2342.19200300.100.1.2.25", "DomainComponentAttributeType"),
 
+    DESCRIPTION("2.5.4.13", "DescriptionAttributeType"),
+    ROLE("2.5.4.72", "RoleAttributeType"),
+
     DATE_OF_BIRTH("1.3.6.1.5.5.7.9.1", "DateOfBirth"),
     PLACE_OF_BIRTH("1.3.6.1.5.5.7.9.2", "PlaceOfBirth"),
     GENDER("1.3.6.1.5.5.7.9.3", "Gender"),

--- a/kse/src/main/java/org/kse/crypto/x509/KseX500NameStyle.java
+++ b/kse/src/main/java/org/kse/crypto/x509/KseX500NameStyle.java
@@ -75,6 +75,8 @@ public class KseX500NameStyle extends BCStyle {
         DEFAULT_SYMBOLS.put(TELEPHONE_NUMBER, "TelephoneNumber");
         DEFAULT_SYMBOLS.put(NAME, "Name");
         DEFAULT_SYMBOLS.put(ORGANIZATION_IDENTIFIER, "organizationIdentifier");
+        DEFAULT_SYMBOLS.put(DESCRIPTION, "Description");
+        DEFAULT_SYMBOLS.put(ROLE, "Role");
 
         DEFAULT_LOOKUP.put("c", C);
         DEFAULT_LOOKUP.put("o", O);

--- a/kse/src/main/java/org/kse/gui/dnchooser/OidDisplayNameMapping.java
+++ b/kse/src/main/java/org/kse/gui/dnchooser/OidDisplayNameMapping.java
@@ -27,7 +27,8 @@ import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.style.BCStyle;
 
 /**
- * This class holds the mapping between the OIDs and the display names of RDN components.
+ * This class holds the mapping between the OIDs and the display names of RDN
+ * components.
  */
 public class OidDisplayNameMapping {
 
@@ -54,6 +55,7 @@ public class OidDisplayNameMapping {
     private static final String GENERATION = res.getString("DistinguishedNameChooser.jlGeneration.text");
     private static final String ORG_ID = res.getString("DistinguishedNameChooser.jlOrganizationIdentifier.text");
     private static final String DESCRIPTION = res.getString("DistinguishedNameChooser.jlDescription.text");
+    private static final String ROLE = res.getString("DistinguishedNameChooser.jlRole.text");
 
     private static Map<String, ASN1ObjectIdentifier> displayNameToOID = new HashMap<>();
 
@@ -81,6 +83,7 @@ public class OidDisplayNameMapping {
         displayNameToOID.put(GENERATION, BCStyle.GENERATION);
         displayNameToOID.put(ORG_ID, BCStyle.ORGANIZATION_IDENTIFIER);
         displayNameToOID.put(DESCRIPTION, BCStyle.DESCRIPTION);
+        displayNameToOID.put(ROLE, BCStyle.ROLE);
     }
 
     private static Map<String, String> oidToDisplayName = new HashMap<>();
@@ -109,11 +112,12 @@ public class OidDisplayNameMapping {
         oidToDisplayName.put(BCStyle.GENERATION.getId(), GENERATION);
         oidToDisplayName.put(BCStyle.ORGANIZATION_IDENTIFIER.getId(), ORG_ID);
         oidToDisplayName.put(BCStyle.DESCRIPTION.getId(), DESCRIPTION);
+        oidToDisplayName.put(BCStyle.ROLE.getId(), ROLE);
     }
 
     public static String[] getDisplayNames() {
         return new String[] { CN, OU, O, L, ST, C, E, SN, GIVENNAME, SURNAME, DC, UID, NAME, STREET, TITLE, INITIALS,
-                              PSEUDONYM, DN_QUALIFIER, GENERATION, ORG_ID, DESCRIPTION };
+                PSEUDONYM, DN_QUALIFIER, GENERATION, ORG_ID, DESCRIPTION, ROLE };
     }
 
     public static ASN1ObjectIdentifier getOidForDisplayName(String displayName) {

--- a/kse/src/main/resources/org/kse/crypto/x509/resources.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources.properties
@@ -352,3 +352,6 @@ SCTLogId=Log ID: {0}
 SCTTimestamp=Timestamp: {0}
 SCTExtensions=Extensions: {0}
 SCTSignature=Signature: {0} with {1}
+
+DescriptionAttributeType=Description
+RoleAttributeType=Role

--- a/kse/src/main/resources/org/kse/crypto/x509/resources_es.properties
+++ b/kse/src/main/resources/org/kse/crypto/x509/resources_es.properties
@@ -352,3 +352,5 @@ MSNtdsCaSecurityExt.Value=Valor: {0}
 MSNtdsCaSecurityExt.Unexpected.Element.Warning=Advertencia: Tipo de elemento inesperado: {0}
 MSNtdsObjectSid=Identificador de seguridad de objeto (SID) de MS NTDS (1.3.6.1.4.1.311.25.2.1)
 NoDerEncodeCrl.exception.message=No se pudo codificar en DER la CRL.
+DescriptionAttributeType=Descripción
+RoleAttributeType=Rol

--- a/kse/src/main/resources/org/kse/gui/dnchooser/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/dnchooser/resources.properties
@@ -20,3 +20,4 @@ DistinguishedNameChooser.jlDnQualifier.text               = DN Qualifier (DN_QUA
 DistinguishedNameChooser.jlGeneration.text                = Generation (GENERATION):
 DistinguishedNameChooser.jlOrganizationIdentifier.text    = Organization Identifier (ORG_ID):
 DistinguishedNameChooser.jlDescription.text               = Description (DESCRIPTION):
+DistinguishedNameChooser.jlRole.text                      = Role (ROLE):

--- a/kse/src/main/resources/org/kse/gui/dnchooser/resources_es.properties
+++ b/kse/src/main/resources/org/kse/gui/dnchooser/resources_es.properties
@@ -20,3 +20,4 @@ DistinguishedNameChooser.jlDnQualifier.text               = Calificador DN (DN_Q
 DistinguishedNameChooser.jlGeneration.text                = Generación (GENERATION):
 DistinguishedNameChooser.jlOrganizationIdentifier.text    = Identificador de organización (ORG_ID):
 DistinguishedNameChooser.jlDescription.text               = Descripción (DESCRIPTION):
+DistinguishedNameChooser.jlRole.text                      = Rol (ROLE):


### PR DESCRIPTION
Added support for the Description (2.5.4.13) and Role (2.5.4.72) attributes to the Distinguished Name (DN) system for X.509 certificates.

Before
<img width="755" height="660" alt="image" src="https://github.com/user-attachments/assets/6b3f9df6-73e0-4923-91b0-ac2f7cfe4dad" />

After
<img width="755" height="660" alt="image" src="https://github.com/user-attachments/assets/1c1510e5-fffd-4fce-8009-9cdd9979f892" />
