### PR TITLE
🚸 Improve context menu for multi-selections

### DIFF
--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -2457,11 +2457,12 @@ public final class KseFrame implements StatusBar {
                 (String) unlockKeyAction.getValue(Action.LONG_DESCRIPTION), this);
 
         jpmMultiEntrySel = new JPopupMenu();
+        jpmMultiEntrySel.add(jmiMultiEntryDetails);
+        jpmMultiEntrySel.addSeparator();
         jpmMultiEntrySel.add(jmiMultiEntrySelCut);
         jpmMultiEntrySel.add(jmiMultEntrySelCopy);
         jpmMultiEntrySel.add(jmiMultiEntrySelDelete);
         jpmMultiEntrySel.addSeparator();
-        jpmMultiEntrySel.add(jmiMultiEntryDetails);
         jpmMultiEntrySel.add(jmiMultiEntryExport);
         jpmMultiEntrySel.add(jmiMultiEntryCompare);
         jpmMultiEntrySel.addSeparator();
@@ -2589,6 +2590,7 @@ public final class KseFrame implements StatusBar {
 
                 selectedCertificatesChainDetailsAction.setEnabled(hasCertEntry);
                 exportSelectedCertificatesAction.setEnabled(hasCertEntry);
+                compareCertificateAction.setEnabled(hasCertEntry);
                 unlockKeyAction.setEnabled(hasKeyEntry);
 
                 jpmMultiEntrySel.show(jtKeyStore, x, y);


### PR DESCRIPTION
Hello KSE Team, @kaikramer,

Here is a PR in order to:
- fix #729

---

This pull request makes minor improvements to the key store entry context menu in `KseFrame.java`, focusing on menu organization and action availability.

Menu organization:

* The `jpmMultiEntrySel` popup menu now shows the `Details` item at the top, followed by a separator, improving menu clarity and grouping related actions.

Action availability:

* The `compareCertificateAction` is now enabled only when a certificate entry is present, ensuring appropriate menu options based on selection.