### PR TITLE
💥Change accelerator key of `Examine Clipboard` from 'L' to 'B'

### DIFF
--- a/kse/src/main/java/org/kse/gui/actions/ExamineClipboardAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ExamineClipboardAction.java
@@ -90,7 +90,7 @@ public class ExamineClipboardAction extends KeyStoreExplorerAction {
     public ExamineClipboardAction(KseFrame kseFrame) {
         super(kseFrame);
 
-        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('L', Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
+        putValue(ACCELERATOR_KEY, KeyStroke.getKeyStroke('B', Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
         putValue(LONG_DESCRIPTION, res.getString("ExamineClipboardAction.statusbar"));
         putValue(NAME, res.getString("ExamineClipboardAction.text"));
         putValue(SHORT_DESCRIPTION, res.getString("ExamineClipboardAction.tooltip"));


### PR DESCRIPTION
Hello KSE Team, @kaikramer 

Here is a PR in oder to:
- Change accelerator key of `Examine Clipboard` from 'L' to 'B' _(💥 minor breaking change accepted)_
- fix #730


---

This pull request makes a minor update to the keyboard shortcut for the "Examine Clipboard" action. The shortcut has been changed from Ctrl+L (or Cmd+L on macOS) to Ctrl+B (or Cmd+B).

* Changed the accelerator key for `ExamineClipboardAction` from `'L'` to `'B'` in `ExamineClipboardAction.java`.