### PR TITLE
Certificate view does not show correct hierarchy when certificates use Brainpool curves

### DIFF
--- a/kse/src/main/java/org/kse/crypto/x509/X509CertUtil.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509CertUtil.java
@@ -663,12 +663,12 @@ public final class X509CertUtil {
     public static boolean verifyCertificate(X509Certificate signedCert, X509Certificate signingCert)
             throws CryptoException {
         try {
-            signedCert.verify(signingCert.getPublicKey());
+            signedCert.verify(signingCert.getPublicKey(), KSE.BC);
             return true;
         } catch (InvalidKeyException | SignatureException ex) {
             // Verification failed
             return false;
-        } catch (NoSuchProviderException | NoSuchAlgorithmException | CertificateException ex) {
+        } catch (NoSuchAlgorithmException | CertificateException ex) {
             // Problem verifying
             throw new CryptoException(res.getString("NoVerifyCertificate.exception.message"), ex);
         }


### PR DESCRIPTION
Before:

<img width="447" height="152" alt="grafik" src="https://github.com/user-attachments/assets/034dd37b-d121-4c43-a540-ba339330b41b" />

After:

<img width="485" height="157" alt="grafik" src="https://github.com/user-attachments/assets/b7f559ac-510b-44c7-a094-087507bef4fc" />


The reason is a exception during signature verification that gets "lost" and the verification just returns `false`:

<img width="1720" height="426" alt="grafik" src="https://github.com/user-attachments/assets/85915673-c655-483b-8022-99a167d4a076" />

