### PR TITLE
📝 Add DeepWiki badge to `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/github/license/kaikramer/keystore-explorer)](https://github.com/kaikramer/keystore-explorer/blob/master/LICENSE)
 [![Packaging status](https://repology.org/badge/tiny-repos/keystore-explorer.svg)](https://repology.org/project/keystore-explorer/versions)
 [![Translation status](https://hosted.weblate.org/widgets/keystore-explorer/-/svg-badge.svg)](https://hosted.weblate.org/projects/keystore-explorer/)
-
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kaikramer/keystore-explorer)
 
 KeyStore Explorer is a free GUI replacement for the Java command-line utilities keytool and jarsigner.
 


### PR DESCRIPTION
Hello @kaikramer 

I just discover: https://deepwiki.com/

And KSE code is already indexed within:
- https://deepwiki.com/kaikramer/keystore-explorer

Then here is a PR in order :
- add a badge to go directly on the KSE doc, from the root `readme.md` page.

Regards,
Th.
