### PR TITLE
Construct full chain for PKCS#12 key store.

### DIFF
--- a/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
@@ -161,6 +161,22 @@ public enum KeyStoreType {
     }
 
     /**
+     * Are certificate chains built when loading the key store?
+     * 
+     * For PKCS #12 key stores, a collection of certificates are stored and then
+     * linked to the private key entries. The certificate is chain is built when
+     * loading the key store.
+     * For PEM key stores, the file contains a collection of certificates, and the
+     * certificate is chain is built when loading the key store.
+     * For all other key store types, the chain is stored with the private key entry.
+     * 
+     * @return
+     */
+    public boolean hasDynamicCertificateChains() {
+        return this == PKCS12 || this == PEM; 
+    }
+
+    /**
      * Does this KeyStore type support secret key entries?
      *
      * @return True, if secret key entries are supported by this KeyStore type

--- a/kse/src/main/java/org/kse/crypto/keystore/KeyStoreUtil.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/KeyStoreUtil.java
@@ -83,7 +83,12 @@ public final class KeyStoreUtil {
                                                            keyStoreType.jce()));
         }
 
-        KseKeyStore keyStore = new KseKeyStore(getKeyStoreInstance(keyStoreType));
+        KseKeyStore keyStore;
+        if (keyStoreType == KeyStoreType.PKCS12) {
+            keyStore = new Pkcs12KeyStoreAdapter(getKeyStoreInstance(keyStoreType));
+        } else {
+            keyStore = new KseKeyStore(getKeyStoreInstance(keyStoreType));
+        }
 
         try {
             keyStore.load(null, null);

--- a/kse/src/main/java/org/kse/crypto/keystore/KeyStoreUtil.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/KeyStoreUtil.java
@@ -83,12 +83,7 @@ public final class KeyStoreUtil {
                                                            keyStoreType.jce()));
         }
 
-        KseKeyStore keyStore;
-        if (keyStoreType == KeyStoreType.PKCS12) {
-            keyStore = new Pkcs12KeyStoreAdapter(getKeyStoreInstance(keyStoreType));
-        } else {
-            keyStore = new KseKeyStore(getKeyStoreInstance(keyStoreType));
-        }
+        KseKeyStore keyStore = new KseKeyStore(getKeyStoreInstance(keyStoreType));
 
         try {
             keyStore.load(null, null);

--- a/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
@@ -32,14 +32,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
+import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.KeyStore.Entry;
+import java.security.KeyStore.ProtectionParameter;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -74,6 +79,7 @@ import org.bouncycastle.asn1.pkcs.Pfx;
 import org.bouncycastle.asn1.pkcs.SafeBag;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.jcajce.spec.PBKDF2KeySpec;
+import org.kse.crypto.CryptoException;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.crypto.x509.X509CertUtil;
 
@@ -110,19 +116,98 @@ public class Pkcs12KeyStoreAdapter extends KseKeyStore {
     }
 
     @Override
+    public void setKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
+        super.setKeyEntry(alias, key, password, rebuildChain(chain));
+    }
+
+    @Override
+    public void setKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
+        super.setKeyEntry(alias, key, rebuildChain(chain));
+    }
+
+    @Override
+    public void setEntry(String alias, Entry entry, ProtectionParameter protParam) throws KeyStoreException {
+        if (entry instanceof KeyStore.PrivateKeyEntry) {
+            KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry) entry;
+            entry = new KeyStore.PrivateKeyEntry(pkEntry.getPrivateKey(), rebuildChain(pkEntry.getCertificateChain()),
+                    pkEntry.getAttributes());
+        }
+        super.setEntry(alias, entry, protParam);
+    }
+
+    /**
+     * The intent of this method is to help maintain consistency of operations for PKCS#12 key stores.
+     * Specifically, if a key pair with a partial chain only containing the leaf or intermediate CA
+     * certificates and the key store contains certificates for the whole chain, then when importing
+     * or pasting the key pair with partial chain, the partial chain is stored. But, the moment a user
+     * performs an action that will trigger the undo/redo code, the key store is copied. While copying,
+     * the Java PKCS12 key store provider will identify that the whole chain is present in the key store
+     * and populate the key pair entry with the full chain.
+     *
+     * Generally, this behavior is irrelevant for most KSE operations, but for the Append Certificate
+     * action it is confusing to see a partial chain in DViewCertificate, but then to have the append
+     * certificate action state that the chain's end certificate is already self-signed.
+     *
+     * Steps:
+     * 1. Paste/import key pair with partial chain
+     * 2. View certificate details: leaf -> subCA
+     * 3. Add new key pair (or any operation that affects undo/redo)
+     * 4. View certificate details: leaf -> subCA -> root
+     *
+     * This method will attempt to ensure consistency by rebuilding the chain when the key pair is added
+     * to the key store.
+     * Steps:
+     * 1. Paste/import key pair with partial chain
+     * 2. View certificate details: leaf -> subCA -> root
+     * 3. Add new key pair (or any operation that affects undo/redo)
+     * 4. View certificate details: leaf -> subCA -> root
+     *
+     * There is nothing wrong, per se, with the partial chain so this method simply falls back on returning
+     * the original chain if an exception occurs or if there aren't any other certificates.
+     *
+     * @param chain The certificate chain
+     * @return A potentially augmented certificate chain.
+     */
+    private Certificate[] rebuildChain(Certificate[] chain) {
+        try {
+            Certificate cert = chain[chain.length - 1];
+            if (!X509CertUtil.isCertificateSelfSigned(X509CertUtil.convertCertificate(cert))) {
+                Set<Certificate> certs = extractAllCertificates();
+                certs.addAll(Arrays.asList(chain));
+                X509Certificate[] orderedChain = X509CertUtil
+                        .orderX509CertChain(X509CertUtil.convertCertificates(certs.toArray(Certificate[]::new)));
+                // The goal is to update the chain if it's not anchored with a root.
+                // If the ordered chain is the same length or less then the goal is
+                // not satisfied and the original chain should be used.
+                if (orderedChain.length > chain.length) {
+                    chain = orderedChain;
+                }
+            }
+        } catch (CryptoException e) {
+            // Ignore. Just return the original chain if there was a problem with
+            // converting or extracting certificates.
+        }
+        return chain;
+    }
+
+    @Override
     public void load(InputStream stream, char[] password)
             throws NoSuchAlgorithmException, CertificateException, IOException {
 
-        certificateFactory = CertificateFactory.getInstance(X509CertUtil.X509_CERT_TYPE);
+        if (stream != null) {
+            certificateFactory = CertificateFactory.getInstance(X509CertUtil.X509_CERT_TYPE);
 
-        byte[] data = stream.readAllBytes();
+            byte[] data = stream.readAllBytes();
 
-        super.load(new ByteArrayInputStream(data), password);
+            super.load(new ByteArrayInputStream(data), password);
 
-        Set<Certificate> visibleCerts = extractAllCertificates();
-        invisibleCerts = parseP12(data, password).stream() //
-                .filter(ce -> !visibleCerts.contains(ce.cert)) //
-                .toList();
+            Set<Certificate> visibleCerts = extractAllCertificates();
+            invisibleCerts = parseP12(data, password).stream() //
+                    .filter(ce -> !visibleCerts.contains(ce.cert)) //
+                    .toList();
+        } else {
+            super.load(stream, password);
+        }
     }
 
     private Set<Certificate> extractAllCertificates() {

--- a/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
@@ -115,6 +115,14 @@ public class Pkcs12KeyStoreAdapter extends KseKeyStore {
 
         certificateFactory = CertificateFactory.getInstance(X509CertUtil.X509_CERT_TYPE);
 
+        if (stream == null) {
+            super.load(stream, password);
+
+            invisibleCerts = Collections.EMPTY_LIST;
+
+            return;
+        }
+
         byte[] data = stream.readAllBytes();
 
         super.load(new ByteArrayInputStream(data), password);

--- a/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/Pkcs12KeyStoreAdapter.java
@@ -32,19 +32,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
-import java.security.Key;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.KeyStore.Entry;
-import java.security.KeyStore.ProtectionParameter;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -79,7 +74,6 @@ import org.bouncycastle.asn1.pkcs.Pfx;
 import org.bouncycastle.asn1.pkcs.SafeBag;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.jcajce.spec.PBKDF2KeySpec;
-import org.kse.crypto.CryptoException;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.crypto.x509.X509CertUtil;
 
@@ -116,98 +110,19 @@ public class Pkcs12KeyStoreAdapter extends KseKeyStore {
     }
 
     @Override
-    public void setKeyEntry(String alias, Key key, char[] password, Certificate[] chain) throws KeyStoreException {
-        super.setKeyEntry(alias, key, password, rebuildChain(chain));
-    }
-
-    @Override
-    public void setKeyEntry(String alias, byte[] key, Certificate[] chain) throws KeyStoreException {
-        super.setKeyEntry(alias, key, rebuildChain(chain));
-    }
-
-    @Override
-    public void setEntry(String alias, Entry entry, ProtectionParameter protParam) throws KeyStoreException {
-        if (entry instanceof KeyStore.PrivateKeyEntry) {
-            KeyStore.PrivateKeyEntry pkEntry = (KeyStore.PrivateKeyEntry) entry;
-            entry = new KeyStore.PrivateKeyEntry(pkEntry.getPrivateKey(), rebuildChain(pkEntry.getCertificateChain()),
-                    pkEntry.getAttributes());
-        }
-        super.setEntry(alias, entry, protParam);
-    }
-
-    /**
-     * The intent of this method is to help maintain consistency of operations for PKCS#12 key stores.
-     * Specifically, if a key pair with a partial chain only containing the leaf or intermediate CA
-     * certificates and the key store contains certificates for the whole chain, then when importing
-     * or pasting the key pair with partial chain, the partial chain is stored. But, the moment a user
-     * performs an action that will trigger the undo/redo code, the key store is copied. While copying,
-     * the Java PKCS12 key store provider will identify that the whole chain is present in the key store
-     * and populate the key pair entry with the full chain.
-     *
-     * Generally, this behavior is irrelevant for most KSE operations, but for the Append Certificate
-     * action it is confusing to see a partial chain in DViewCertificate, but then to have the append
-     * certificate action state that the chain's end certificate is already self-signed.
-     *
-     * Steps:
-     * 1. Paste/import key pair with partial chain
-     * 2. View certificate details: leaf -> subCA
-     * 3. Add new key pair (or any operation that affects undo/redo)
-     * 4. View certificate details: leaf -> subCA -> root
-     *
-     * This method will attempt to ensure consistency by rebuilding the chain when the key pair is added
-     * to the key store.
-     * Steps:
-     * 1. Paste/import key pair with partial chain
-     * 2. View certificate details: leaf -> subCA -> root
-     * 3. Add new key pair (or any operation that affects undo/redo)
-     * 4. View certificate details: leaf -> subCA -> root
-     *
-     * There is nothing wrong, per se, with the partial chain so this method simply falls back on returning
-     * the original chain if an exception occurs or if there aren't any other certificates.
-     *
-     * @param chain The certificate chain
-     * @return A potentially augmented certificate chain.
-     */
-    private Certificate[] rebuildChain(Certificate[] chain) {
-        try {
-            Certificate cert = chain[chain.length - 1];
-            if (!X509CertUtil.isCertificateSelfSigned(X509CertUtil.convertCertificate(cert))) {
-                Set<Certificate> certs = extractAllCertificates();
-                certs.addAll(Arrays.asList(chain));
-                X509Certificate[] orderedChain = X509CertUtil
-                        .orderX509CertChain(X509CertUtil.convertCertificates(certs.toArray(Certificate[]::new)));
-                // The goal is to update the chain if it's not anchored with a root.
-                // If the ordered chain is the same length or less then the goal is
-                // not satisfied and the original chain should be used.
-                if (orderedChain.length > chain.length) {
-                    chain = orderedChain;
-                }
-            }
-        } catch (CryptoException e) {
-            // Ignore. Just return the original chain if there was a problem with
-            // converting or extracting certificates.
-        }
-        return chain;
-    }
-
-    @Override
     public void load(InputStream stream, char[] password)
             throws NoSuchAlgorithmException, CertificateException, IOException {
 
-        if (stream != null) {
-            certificateFactory = CertificateFactory.getInstance(X509CertUtil.X509_CERT_TYPE);
+        certificateFactory = CertificateFactory.getInstance(X509CertUtil.X509_CERT_TYPE);
 
-            byte[] data = stream.readAllBytes();
+        byte[] data = stream.readAllBytes();
 
-            super.load(new ByteArrayInputStream(data), password);
+        super.load(new ByteArrayInputStream(data), password);
 
-            Set<Certificate> visibleCerts = extractAllCertificates();
-            invisibleCerts = parseP12(data, password).stream() //
-                    .filter(ce -> !visibleCerts.contains(ce.cert)) //
-                    .toList();
-        } else {
-            super.load(stream, password);
-        }
+        Set<Certificate> visibleCerts = extractAllCertificates();
+        invisibleCerts = parseP12(data, password).stream() //
+                .filter(ce -> !visibleCerts.contains(ce.cert)) //
+                .toList();
     }
 
     private Set<Certificate> extractAllCertificates() {

--- a/kse/src/main/java/org/kse/gui/actions/AppendToCertificateChainAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/AppendToCertificateChainAction.java
@@ -23,11 +23,13 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.security.Key;
 import java.security.cert.X509Certificate;
+import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 
+import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KseKeyStore;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CurrentDirectory;
@@ -85,6 +87,7 @@ public class AppendToCertificateChainAction extends KeyStoreExplorerAction imple
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KseKeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = newState.getType();
 
             Key privKey = keyStore.getKey(alias, password.toCharArray());
 
@@ -93,6 +96,46 @@ public class AppendToCertificateChainAction extends KeyStoreExplorerAction imple
 
             // Certificate to append to is the end one in the chain
             X509Certificate certToAppendTo = certChain[certChain.length - 1];
+
+            if (keyStoreType.hasDynamicCertificateChains()) {
+                // The PKCS12 and PEM key store types do not store full chains. They store
+                // collections of certificates, which are then used to build the full chain
+                // for the private key entries when the key store is loaded. When a key pair
+                // entry containing just an end-entity certificate or a partial chain is
+                // imported into a PKCS12 or PEM key store that already has the necessary
+                // certificates for building the entire chain, then next time the key store
+                // is loaded the new entry will have the entire certificate chain. The undo/redo
+                // system loads the new state from the current state causing the potential for
+                // the newState key store to have a different certificate chain than the currentState
+                // key store.
+                KseKeyStore currentKeyStore = currentState.getKeyStore();
+
+                X509Certificate[] currentCertChain = X509CertUtil.orderX509CertChain(
+                        X509CertUtil.convertCertificates(currentKeyStore.getCertificateChain(alias)));
+
+                // Certificate to append to is the end one in the chain
+                X509Certificate currentCertToAppendTo = currentCertChain[currentCertChain.length - 1];
+
+                if (!currentCertToAppendTo.equals(certToAppendTo)) {
+                    int selection = JOptionPane.showConfirmDialog(frame,
+                            MessageFormat.format(
+                                    res.getString("AppendToCertificateChainAction.DifferentChains.message"),
+                                    keyStoreType.friendly()),
+                            res.getString("AppendToCertificateChainAction.AppendToCertificateChain.Title"),
+                            JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+                    if (selection == JOptionPane.YES_OPTION) {
+                        currentState.append(newState);
+
+                        kseFrame.updateControls(true);
+
+                        JOptionPane.showMessageDialog(frame, res.getString(
+                                "AppendToCertificateChainAction.DifferentChainsUpdated.message"), res.getString(
+                                "AppendToCertificateChainAction.AppendToCertificateChain.Title"), JOptionPane.INFORMATION_MESSAGE);
+                    }
+
+                    return;
+                }
+            }
 
             if (X509CertUtil.isCertificateSelfSigned(certToAppendTo)) {
                 JOptionPane.showMessageDialog(frame, res.getString(

--- a/kse/src/main/java/org/kse/gui/actions/RemoveFromCertificateChainAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/RemoveFromCertificateChainAction.java
@@ -22,10 +22,13 @@ package org.kse.gui.actions;
 import java.awt.Toolkit;
 import java.security.Key;
 import java.security.cert.X509Certificate;
+import java.text.MessageFormat;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 
+import org.kse.crypto.keystore.KeyStoreType;
+import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.crypto.keystore.KseKeyStore;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
@@ -81,6 +84,7 @@ public class RemoveFromCertificateChainAction extends KeyStoreExplorerAction imp
             KeyStoreState newState = currentState.createBasisForNextState(this);
 
             KseKeyStore keyStore = newState.getKeyStore();
+            KeyStoreType keyStoreType = newState.getType();
 
             Key privKey = keyStore.getKey(alias, password.toCharArray());
 
@@ -104,6 +108,36 @@ public class RemoveFromCertificateChainAction extends KeyStoreExplorerAction imp
             keyStore.deleteEntry(alias);
 
             keyStore.setKeyEntry(alias, privKey, password.toCharArray(), newCertChain);
+
+            if (keyStoreType.hasDynamicCertificateChains()) {
+                // The PKCS12 and PEM key store types do not store full chains. They store
+                // collections of certificates, which are then used to build the full chain
+                // for the private key entries when the key store is loaded. When a certificate
+                // is removed from the chain, the undo/redo system makes a copy of the key store
+                // and the chain is rebuilt using all the certificates in the key store. The same
+                // thing happens when re-opening the key store, the chain is rebuilt an it appears 
+                // that the removal did not take place.
+                KseKeyStore copiedKeyStore = KeyStoreUtil.copy(keyStore);
+
+                X509Certificate[] copiedCertChain = X509CertUtil.orderX509CertChain(
+                        X509CertUtil.convertCertificates(copiedKeyStore.getCertificateChain(alias)));
+
+                X509Certificate topCert = copiedCertChain[copiedCertChain.length - 1];
+
+                // If the top certificate after the copy is not the top certificate after removal,
+                // then it is not possible to edit the certificate chain using the current key store.
+                // Need to copy to an empty key store or convert to JKS, JCEKS, or BKS.
+                if (!topCert.equals(newCertChain[newCertChain.length - 1])) {
+                    JOptionPane.showMessageDialog(frame,
+                            MessageFormat.format(
+                                    res.getString("RemoveFromCertificateChainAction.AutomaticRebuild.message"),
+                                    keyStoreType.friendly()),
+                            res.getString("RemoveFromCertificateChainAction.RemoveFromCertificateChain.Title"),
+                            JOptionPane.INFORMATION_MESSAGE);
+
+                    return;
+                }
+            }
 
             currentState.append(newState);
 

--- a/kse/src/main/resources/org/kse/gui/actions/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/actions/resources.properties
@@ -10,6 +10,8 @@ AppendToCertificateChainAction.AppendCertificate.button                   = Appe
 AppendToCertificateChainAction.AppendToCertificateChain.Title             = Append Certificate
 AppendToCertificateChainAction.AppendToCertificateChainSuccessful.message = Append Certificate Successful.
 AppendToCertificateChainAction.CannotAppendCertSelfSigned.message         = Cannot append a certificate to the certificate chain as\nthe chain's end certificate is self-signed.
+AppendToCertificateChainAction.DifferentChains.message                    = The certificate chain does not match the chain that exists in the key store. The {0} key store type automatically builds the certificate chain using all available certificates. To manually edit the certificate chain, convert the key store to JKS, JCEKS, or BKS or copy the entry to an empty PKCS #12 key store.\n\nDo you want to update the current state with the rebuilt chain?
+AppendToCertificateChainAction.DifferentChainsUpdated.message             = Updated the certificate chain.
 AppendToCertificateChainAction.NoMultipleAppendCert.message               = Only one certificate may be appended to a\ncertificate chain at a time.  The certificate file\ncontained more than one certificate.
 AppendToCertificateChainAction.statusbar                                  = Append a certificate to the end of the Key Pair entry's certificate chain
 AppendToCertificateChainAction.text                                       = Append Certificate
@@ -500,6 +502,7 @@ ReloadAction.statusbar                               = Reload the KeyStore from 
 ReloadAction.text                                    = Reload
 ReloadAction.tooltip                                 = Reload
 
+RemoveFromCertificateChainAction.AutomaticRebuild.message                     = Cannot remove a certificate from the certificate chain as the next time the key store is opened or reloaded the removed certificate will be restored. The {0} key store type automatically builds the certificate chain using all available certificates. To manually edit the certificate chain, convert the key store to JKS, JCEKS, or BKS or copy the entry to an empty PKCS #12 key store.
 RemoveFromCertificateChainAction.CannotRemoveOnlyCert.message                 = Cannot remove a certificate from the certificate chain\nas it only contains one certificate.
 RemoveFromCertificateChainAction.RemoveFromCertificateChain.Title             = Remove Certificate
 RemoveFromCertificateChainAction.RemoveFromCertificateChainSuccessful.message = Remove Certificate Successful.


### PR DESCRIPTION
This PR addresses an unusual corner case, but it also introduces other side effects so it might be something we decide to just discard.

When trying to append a root certificate to a partial certificate chain, I encountered this message:
<img width="345" height="87" alt="image" src="https://github.com/user-attachments/assets/21dcbb3f-7e08-4dca-a45f-ccb67b1a9e8f" />

But when I view the certificate details, I see this:
<img width="337" height="209" alt="image" src="https://github.com/user-attachments/assets/afed03a5-20f3-4d04-ac94-f9a84b4f0335" />

This was confusing since when I looked at the details, I only saw a partial chain, but KSE wouldn't allow me to append the root certificate. If I saved and reopened the key store, then I saw that the full chain was populated.

Investigation shows the following:

1. AppendCertificateAction copies the key store before checking to see if the end of the chain is self-signed.
2. Key store copy uses a store/load combination to clone the key store
3. During load, the Java PKCS12 key store provider builds out the full chain using certificates from other private key entries for the private key entry that previously had a partial chain
4. AppendCertificateAction does not see the original partial chain, but sees the full chain and displays the error message.

This PR updates the Pkcs12KeyStoreAdapter so that it tries to rebuild any partial chains using available certificates so that KSE is consistent with the Java PKCS12 key store implementation.

The side-effect is that in this scenario (multiple key pairs all containing a chain up to the same root cert), it is not possible to remove a certificate from the chain since the Pkcs12KeyStoreAdapter will keep rebuilding it. Even if this PR is not merged, there is still the possibility that a removed certificate is not really removed. If the P12 file contains the full chain due to other key pairs using the same CA certificates, when the PKCS12 provider reads the key store, it will rebuild the chain anyway.

This condition only affects the PKCS12 and PEM (not addressed by this PR) key store provider. The JKS, JCEKS, BKS, UBER key store types are not affected.

Perhaps a better solution is to have the AppendCertificateAction identify when the current state contains the partial chain and the new state contains a full chain and have it tell the user what is happening.

I have attached the certs for reproducing the behavior if you want to play with it yourself. The password is "password" for all P12 files: [p12-chain-building.zip](https://github.com/user-attachments/files/26253065/p12-chain-building.zip).

Steps to Reproduce:
1. Create a new PKCS12 key store
2. Import gnu-subca.p12
3. Import gnu-leaf.p12
4. Attempt to append a certificate to the chain for the leaf certificate

From what I can tell, the partial chain is only an artifact of using GnuTLS certtool. The certtool P12 command only allows for a single CA certificate so it only generates P12 files with partial chains for key pairs so it's not likely regular users are going to encounter this. I used to use certtool for generating all my certs before I switched to use KSE.