### PR TITLE
Fix the use of the incorrect AKI when adding the Authority Key Identifier extension.

### DIFF
--- a/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509Ext.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -354,6 +355,20 @@ public class X509Ext {
      */
     public static byte[] wrapInOctetString(byte[] extensionValue) throws IOException {
         return new DEROctetString(extensionValue).getEncoded(ASN1Encoding.DER);
+    }
+
+    /**
+     * Gets the Subject Key Identifier extension for the certificate.
+     *
+     * @param cert The certificate with or without a Subject Key Identifier extension.
+     * @return The SubjectKeyIdentifier if present else null.
+     */
+    public static SubjectKeyIdentifier getSubjectKeyIdentifier(X509Certificate cert) {
+        byte[] skiExtBytes = cert.getExtensionValue(X509ExtensionType.SUBJECT_KEY_IDENTIFIER.oid());
+        if (skiExtBytes == null) {
+            return null;
+        }
+        return SubjectKeyIdentifier.getInstance(unwrapExtension(skiExtBytes));
     }
 
     private static String lookupFriendlyName(ASN1ObjectIdentifier oid) {

--- a/kse/src/main/java/org/kse/crypto/x509/X509ExtensionSetUpdater.java
+++ b/kse/src/main/java/org/kse/crypto/x509/X509ExtensionSetUpdater.java
@@ -52,12 +52,12 @@ public class X509ExtensionSetUpdater {
      * @param issuerPublicKey        New issuer public key
      * @param issuerCertName         New issuer DN
      * @param issuerCertSerialNumber New SN
-     * @param issuerSkiExt           New issuer SKI extension
+     * @param issuerSki              New issuer SKI extension
      * @throws CryptoException For example when hash value cannot be calculated
      * @throws IOException     If the content cannot be encoded
      */
     public static void update(X509ExtensionSet extensionSet, PublicKey subjectPublicKey, PublicKey issuerPublicKey,
-                              X500Name issuerCertName, BigInteger issuerCertSerialNumber, byte[] issuerSkiExt)
+                              X500Name issuerCertName, BigInteger issuerCertSerialNumber, SubjectKeyIdentifier issuerSki)
             throws CryptoException, IOException {
 
         Set<String> allExtensions = new HashSet<>(extensionSet.getCriticalExtensionOIDs());
@@ -67,7 +67,7 @@ public class X509ExtensionSetUpdater {
 
             switch (X509ExtensionType.resolveOid(extensionOid)) {
             case AUTHORITY_KEY_IDENTIFIER:
-                updateAKI(extensionSet, extensionOid, issuerPublicKey, issuerCertName, issuerCertSerialNumber, issuerSkiExt);
+                updateAKI(extensionSet, extensionOid, issuerPublicKey, issuerCertName, issuerCertSerialNumber, issuerSki);
                 break;
             case SUBJECT_KEY_IDENTIFIER:
                 updateSKI(extensionSet, extensionOid, subjectPublicKey);
@@ -92,7 +92,7 @@ public class X509ExtensionSetUpdater {
     }
 
     private static void updateAKI(X509ExtensionSet extensionSet, String extensionOid, PublicKey newIssuerPublicKey,
-                                  X500Name newIssuerCertName, BigInteger newIssuerSerialNumber, byte[] issuerSkiExt)
+                                  X500Name newIssuerCertName, BigInteger newIssuerSerialNumber, SubjectKeyIdentifier issuerSki)
             throws CryptoException, IOException {
 
         // extract old AKI data
@@ -103,10 +103,8 @@ public class X509ExtensionSetUpdater {
 
         // generate new values
         byte[] newKeyIdentifier = new KeyIdentifierGenerator(newIssuerPublicKey).generate160BitHashId();
-        if (issuerSkiExt != null) {
-            // The *issuer* subject key identifier is the *issued* cert's authority key identifier
-            newKeyIdentifier = SubjectKeyIdentifier.getInstance(X509Ext.unwrapExtension(issuerSkiExt))
-                    .getKeyIdentifier();
+        if (issuerSki != null) {
+            newKeyIdentifier = issuerSki.getKeyIdentifier();
         }
         GeneralNames newCertIssuer = new GeneralNames(new GeneralName[] { new GeneralName(newIssuerCertName) });
 

--- a/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
+++ b/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
@@ -41,11 +41,8 @@ import java.util.TreeMap;
 
 import javax.crypto.SecretKey;
 
-import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.KeyInfo;
 import org.kse.crypto.digest.DigestType;
@@ -58,6 +55,8 @@ import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.crypto.x509.KseX500NameStyle;
 import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
+import org.kse.crypto.x509.X509Ext;
+import org.kse.crypto.x509.X509ExtensionType;
 import org.kse.gui.table.ToolTipTableModel;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -502,9 +501,7 @@ public class KeyStoreTableModel extends ToolTipTableModel {
     private String getCertificateSKI(String alias, KseKeyStore keyStore) throws CryptoException, KeyStoreException {
         X509Certificate x509Cert = getCertificate(alias, keyStore);
         try {
-            byte[] skiValue = x509Cert.getExtensionValue(Extension.subjectKeyIdentifier.getId());
-            byte[] octets = DEROctetString.getInstance(skiValue).getOctets();
-            byte[] skiBytes = SubjectKeyIdentifier.getInstance(octets).getKeyIdentifier();
+            byte[] skiBytes = X509Ext.getSubjectKeyIdentifier(x509Cert).getKeyIdentifier();
             return HexUtil.getHexString(skiBytes);
         } catch (Exception e) {
             return "-";
@@ -514,8 +511,8 @@ public class KeyStoreTableModel extends ToolTipTableModel {
     private String getCertificateAKI(String alias, KseKeyStore keyStore) throws CryptoException, KeyStoreException {
         X509Certificate x509Cert = getCertificate(alias, keyStore);
         try {
-            byte[] akiValue = x509Cert.getExtensionValue(Extension.authorityKeyIdentifier.getId());
-            byte[] octets = DEROctetString.getInstance(akiValue).getOctets();
+            byte[] akiValue = x509Cert.getExtensionValue(X509ExtensionType.AUTHORITY_KEY_IDENTIFIER.oid());
+            byte[] octets = X509Ext.unwrapExtension(akiValue);
             byte[] akiBytes = AuthorityKeyIdentifier.getInstance(octets).getKeyIdentifierOctets();
             return HexUtil.getHexString(akiBytes);
         } catch (Exception e) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPairCert.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DGenerateKeyPairCert.java
@@ -53,6 +53,7 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.kse.KSE;
 import org.kse.crypto.CryptoException;
 import org.kse.crypto.keypair.KeyPairType;
@@ -60,6 +61,7 @@ import org.kse.crypto.signing.SignatureType;
 import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.crypto.x509.X509CertificateGenerator;
+import org.kse.crypto.x509.X509Ext;
 import org.kse.crypto.x509.X509ExtensionSet;
 import org.kse.crypto.x509.X509ExtensionSetUpdater;
 import org.kse.crypto.x509.X509ExtensionType;
@@ -130,10 +132,13 @@ public class DGenerateKeyPairCert extends JEscDialog {
      * Creates a new DGenerateKeyPairCert dialog.
      *
      * @param parent           The parent frame
+     * @param kseFrame         The KSE Frame
      * @param title            The dialog's title
      * @param keyPair          The key pair to generate the certificate from
      * @param keyPairType      The key pair type
-     * @param issuerPrivateKey The signing key pair (issuer CA)
+     * @param issuerCert       The signing key pair certificate
+     * @param issuerPrivateKey The signing key pair private key (issuer CA)
+     * @param provider         The provider to use.
      * @throws CryptoException A problem was encountered with the supplied key pair
      */
     public DGenerateKeyPairCert(JFrame parent, KseFrame kseFrame, String title, KeyPair keyPair, KeyPairType keyPairType,
@@ -330,7 +335,7 @@ public class DGenerateKeyPairCert extends JEscDialog {
                                                    X500NameUtils.x500PrincipalToX500Name(
                                                            issuerCert.getSubjectX500Principal()),
                                                    issuerCert.getSerialNumber(),
-                                                   issuerCert.getExtensionValue(X509ExtensionType.SUBJECT_KEY_IDENTIFIER.oid()));
+                                                   X509Ext.getSubjectKeyIdentifier(issuerCert));
                 }
             } catch (CryptoException | IOException | NumberFormatException e) {
                 DError.displayError(this, e);
@@ -343,12 +348,12 @@ public class DGenerateKeyPairCert extends JEscDialog {
         PublicKey caPublicKey = null;
         X500Name caIssuerName = null;
         BigInteger caSerialNumber = null;
-        byte[] caIssuerSki = null;
+        SubjectKeyIdentifier caIssuerSki = null;
         if (issuerCert != null) {
             caIssuerName = X500NameUtils.x500PrincipalToX500Name(issuerCert.getIssuerX500Principal());
             caPublicKey = issuerCert.getPublicKey();
             caSerialNumber = issuerCert.getSerialNumber();
-            caIssuerSki = issuerCert.getExtensionValue(X509ExtensionType.SUBJECT_KEY_IDENTIFIER.oid());
+            caIssuerSki = X509Ext.getSubjectKeyIdentifier(issuerCert);
         } else {
             caIssuerName = jdnName.getDistinguishedName(); // May be null
             caPublicKey = keyPair.getPublic();

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAddExtensions.java
@@ -127,7 +127,7 @@ public class DAddExtensions extends JEscDialog {
     private PublicKey issuerPublicKey;
     private X500Name issuerCertName;
     private BigInteger issuerCertSerialNumber;
-    private byte[] issuerSki;
+    private SubjectKeyIdentifier issuerSki;
     private PublicKey subjectPublicKey;
     private X500Name subjectCertName;
 
@@ -145,7 +145,7 @@ public class DAddExtensions extends JEscDialog {
      * @param subjectCertName        Subject DN
      */
     public DAddExtensions(JFrame parent, String title, X509ExtensionSet extensions, PublicKey issuerPublicKey,
-                          X500Name issuerCertName, BigInteger issuerCertSerialNumber, byte[] issuerSki,
+                          X500Name issuerCertName, BigInteger issuerCertSerialNumber, SubjectKeyIdentifier issuerSki,
                           PublicKey subjectPublicKey, X500Name subjectCertName) {
 
         super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
@@ -173,7 +173,7 @@ public class DAddExtensions extends JEscDialog {
      * @param subjectCertName        Subject DN
      */
     public DAddExtensions(JDialog parent, X509ExtensionSet extensions, PublicKey issuerPublicKey,
-                          X500Name issuerCertName, BigInteger issuerCertSerialNumber, byte[] issuerSki,
+                          X500Name issuerCertName, BigInteger issuerCertSerialNumber, SubjectKeyIdentifier issuerSki,
                           PublicKey subjectPublicKey, X500Name subjectCertName) {
 
         super(parent, Dialog.ModalityType.DOCUMENT_MODAL);

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityKeyIdentifier.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DAuthorityKeyIdentifier.java
@@ -51,6 +51,7 @@ import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.kse.crypto.x509.X509ExtensionType;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.crypto.JKeyIdentifier;
@@ -80,7 +81,7 @@ public class DAuthorityKeyIdentifier extends DExtension {
 
     private byte[] value;
     private PublicKey authorityPublicKey;
-    private byte[] authorityKeyIdentifier;
+    private SubjectKeyIdentifier authoritySubjectKeyIdentifier;
 
     /**
      * Creates a new DAuthorityKeyIdentifier dialog.
@@ -89,15 +90,15 @@ public class DAuthorityKeyIdentifier extends DExtension {
      * @param authorityPublicKey        Authority public key
      * @param authorityCertName         Authority certificate name
      * @param authorityCertSerialNumber Authority certificate serial number
-     * @param authorityKeyIdentifier    Authority key identifier
+     * @param authoritySki              Authority subject key identifier extension
      */
     public DAuthorityKeyIdentifier(JDialog parent, PublicKey authorityPublicKey, X500Name authorityCertName,
-                                   BigInteger authorityCertSerialNumber, byte[] authorityKeyIdentifier) {
+                                   BigInteger authorityCertSerialNumber, SubjectKeyIdentifier authoritySki) {
         super(parent);
 
         setTitle(res.getString("DAuthorityKeyIdentifier.Title"));
         this.authorityPublicKey = authorityPublicKey;
-        this.authorityKeyIdentifier = authorityKeyIdentifier;
+        this.authoritySubjectKeyIdentifier = authoritySki;
         initComponents();
         prepopulateWithAuthorityCertDetails(authorityCertName, authorityCertSerialNumber);
     }
@@ -108,14 +109,14 @@ public class DAuthorityKeyIdentifier extends DExtension {
      * @param parent             The parent dialog
      * @param value              Authority Key Identifier DER-encoded
      * @param authorityPublicKey Authority public key
-     * @param authorityKeyIdentifier    Authority key identifier
+     * @param authoritySki       Authority subject key identifier extension
      */
     public DAuthorityKeyIdentifier(JDialog parent, byte[] value, PublicKey authorityPublicKey,
-            byte[] authorityKeyIdentifier) {
+            SubjectKeyIdentifier authoritySki) {
         super(parent);
         setTitle(res.getString("DAuthorityKeyIdentifier.Title"));
         this.authorityPublicKey = authorityPublicKey;
-        this.authorityKeyIdentifier = authorityKeyIdentifier;
+        this.authoritySubjectKeyIdentifier = authoritySki;
         initComponents();
         prepopulateWithValue(value);
     }
@@ -232,8 +233,8 @@ public class DAuthorityKeyIdentifier extends DExtension {
     }
 
     private void prepopulateWithAuthorityCertDetails(X500Name authorityCertName, BigInteger authorityCertSerialNumber) {
-        if (authorityKeyIdentifier != null) {
-            jkiKeyIdentifier.setKeyIdentifier(authorityKeyIdentifier);
+        if (authoritySubjectKeyIdentifier != null) {
+            jkiKeyIdentifier.setKeyIdentifier(authoritySubjectKeyIdentifier.getKeyIdentifier());
         }
 
         if (authorityCertName != null) {

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DSelectStandardExtensionTemplate.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DSelectStandardExtensionTemplate.java
@@ -92,7 +92,7 @@ public class DSelectStandardExtensionTemplate extends JEscDialog {
     private PublicKey authorityPublicKey;
     private PublicKey subjectPublicKey;
     private X500Name subjectCertName;
-    private byte[] issuerSkiExt;
+    private SubjectKeyIdentifier issuerSki;
 
     private boolean cancelled = true;
 
@@ -103,15 +103,15 @@ public class DSelectStandardExtensionTemplate extends JEscDialog {
      * @param authorityPublicKey Key of issuer certificate
      * @param subjectPublicKey   Key of new certificate
      * @param subjectCertName    Subject DN
-     * @param issuerSkiExt       Subject key identifier extension of issuer certificate
+     * @param issuerSki          Subject key identifier extension of issuer certificate
      */
     public DSelectStandardExtensionTemplate(JDialog parent, PublicKey authorityPublicKey, PublicKey subjectPublicKey,
-                                            X500Name subjectCertName, byte[] issuerSkiExt) {
+                                            X500Name subjectCertName, SubjectKeyIdentifier issuerSki) {
         super(parent, Dialog.ModalityType.DOCUMENT_MODAL);
         this.authorityPublicKey = authorityPublicKey;
         this.subjectPublicKey = subjectPublicKey;
         this.subjectCertName = subjectCertName;
-        this.issuerSkiExt = issuerSkiExt;
+        this.issuerSki = issuerSki;
         setTitle(res.getString("DSelectStandardExtensionTemplate.Title"));
         initComponents();
     }
@@ -265,10 +265,8 @@ public class DSelectStandardExtensionTemplate extends JEscDialog {
 
     private void addAuthorityKeyIdentifier(X509ExtensionSet extensionSet) throws CryptoException, IOException {
         byte[] keyIdentifier = new KeyIdentifierGenerator(authorityPublicKey).generate160BitHashId();
-        if (issuerSkiExt != null) {
-            // The *issuer* subject key identifier is the *issued* cert's authority key identifier
-            keyIdentifier = SubjectKeyIdentifier.getInstance(X509Ext.unwrapExtension(issuerSkiExt))
-                    .getKeyIdentifier();
+        if (issuerSki != null) {
+            keyIdentifier = issuerSki.getKeyIdentifier();
         }
         AuthorityKeyIdentifier aki = new AuthorityKeyIdentifier(keyIdentifier);
         byte[] akiEncoded = X509Ext.wrapInOctetString(aki.getEncoded());

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
@@ -73,6 +73,7 @@ import org.kse.crypto.signing.SignatureType;
 import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.crypto.x509.X509CertificateVersion;
+import org.kse.crypto.x509.X509Ext;
 import org.kse.crypto.x509.X509ExtensionSet;
 import org.kse.crypto.x509.X509ExtensionSetUpdater;
 import org.kse.crypto.x509.X509ExtensionType;
@@ -657,7 +658,7 @@ public class DSignCsr extends JEscDialog {
                                            X500NameUtils.x500PrincipalToX500Name(
                                                    issuerCertificate.getSubjectX500Principal()),
                                            issuerCertificate.getSerialNumber(),
-                                           issuerCertificate.getExtensionValue(X509ExtensionType.SUBJECT_KEY_IDENTIFIER.oid()));
+                                           X509Ext.getSubjectKeyIdentifier(issuerCertificate));
         } catch (CryptoException | IOException e) {
             DError.displayError(this, e);
         }
@@ -668,8 +669,7 @@ public class DSignCsr extends JEscDialog {
                                                            X500NameUtils.x500PrincipalToX500Name(
                                                                    issuerCertificate.getSubjectX500Principal()),
                                                            issuerCertificate.getSerialNumber(),
-                                                           issuerCertificate.getExtensionValue(
-                                                                   X509ExtensionType.SUBJECT_KEY_IDENTIFIER.oid()),
+                                                           X509Ext.getSubjectKeyIdentifier(issuerCertificate),
                                                            csrPublicKey, jdnSubjectDN.getDistinguishedName());
         dAddExtensions.setLocationRelativeTo(this);
         dAddExtensions.setVisible(true);


### PR DESCRIPTION
This PR fixes #778.

I refactored the methods to use SubjectKeyIdentifier rather than byte[] and added a helper method to X509Ext for getting the Subject Key Identifier extension as a SubjectKeyIdentifier instance. These changes should reduce the ambiguity of various extension byte arrays (wrapped vs unwrapped).

I tested all paths:
- Manually adding the Authority Key Identifier
- Transferring extensions from another cert
- Transferring extensions from a CSR
- Using the standard template