### PR TITLE
Account for PasswordType when handling key entries.

### DIFF
--- a/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
+++ b/kse/src/main/java/org/kse/gui/KeyStoreTableModel.java
@@ -50,6 +50,7 @@ import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.crypto.keystore.KseKeyStore;
+import org.kse.crypto.secretkey.PasswordType;
 import org.kse.crypto.secretkey.SecretKeyType;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.crypto.x509.KseX500NameStyle;
@@ -456,6 +457,12 @@ public class KeyStoreTableModel extends ToolTipTableModel {
 
             if (secretKeyType != null) {
                 algorithm = secretKeyType.friendly();
+            } else {
+                PasswordType passwordType = PasswordType.resolveJce(algorithm);
+
+                if (passwordType != null) {
+                    algorithm = passwordType.friendly();
+                }
             }
         }
 

--- a/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
@@ -36,6 +36,7 @@ import org.kse.crypto.ecc.EccUtil;
 import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.crypto.keystore.KseKeyStore;
+import org.kse.crypto.secretkey.PasswordType;
 import org.kse.crypto.secretkey.SecretKeyType;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
@@ -213,8 +214,16 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
 
             Key secretKey = currentKeyStore.getKey(alias, password.toCharArray());
 
-            if (!newKeyStoreType.supportsKeyType(SecretKeyType.resolveJce(secretKey.getAlgorithm()))) {
-                return showWarnUnsupportedKey();
+            SecretKeyType secretKeyType = SecretKeyType.resolveJce(secretKey.getAlgorithm());
+            if (secretKeyType != null) {
+                if (!newKeyStoreType.supportsKeyType(secretKeyType)) {
+                    return showWarnUnsupportedKey();
+                }
+            } else {
+                PasswordType passwordType = PasswordType.resolveJce(secretKey.getAlgorithm());
+                if (!newKeyStoreType.supportsPasswordType(passwordType)) {
+                    return showWarnUnsupportedKey();
+                }
             }
 
             if (newKeyStore.containsAlias(alias)) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
@@ -70,6 +70,7 @@ import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KeyStoreUtil;
 import org.kse.crypto.keystore.KseKeyStore;
+import org.kse.crypto.secretkey.PasswordType;
 import org.kse.crypto.secretkey.SecretKeyType;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.crypto.x509.X500NameUtils;
@@ -665,6 +666,12 @@ public class DProperties extends JEscDialog {
 
         if (secretKeyType != null) {
             keyAlg = secretKeyType.friendly();
+        } else {
+            PasswordType passwordType = PasswordType.resolveJce(keyAlg);
+
+            if (passwordType != null) {
+                keyAlg = passwordType.friendly();
+            }
         }
 
         secretKeyNode.add(new DefaultMutableTreeNode(


### PR DESCRIPTION
This PR fixes a Change Type conversion defect when the key store contains passphrase entries, and it will display the friendly name for passphrase algorithm displays. These problems were introduced in PR 655 when when adding the PasswordType enum.

Fixes this error:
<img width="593" height="346" alt="image" src="https://github.com/user-attachments/assets/8a805393-284e-4f27-9fc5-2f7d338f3f3b" />


Before:
<img width="384" height="121" alt="image" src="https://github.com/user-attachments/assets/1c1353ce-7cf6-427e-bb18-93ebc64c8cb2" />
<img width="408" height="202" alt="image" src="https://github.com/user-attachments/assets/e3cb30b9-3183-4a6a-be5d-78d832af3b5c" />

After:
<img width="395" height="114" alt="image" src="https://github.com/user-attachments/assets/bbdbb027-5c16-4325-962a-7cf6daa4bc05" />
<img width="408" height="198" alt="image" src="https://github.com/user-attachments/assets/742f32f7-b8c4-4296-8380-e5b1c9aa6177" />
