### PR TITLE
Automatically handle aliases for key store types (PEM) that don't support aliases.

### DIFF
--- a/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
+++ b/kse/src/main/java/org/kse/crypto/keystore/KeyStoreType.java
@@ -127,6 +127,15 @@ public enum KeyStoreType {
     }
 
     /**
+     * Does the key store support user defined aliases?
+     *
+     * @return True if it does, false otherwise
+     */
+    public boolean supportsAliases() {
+        return this != PEM;
+    }
+
+    /**
      * Are key store entries password protected?
      *
      * @return True if it has, false otherwise

--- a/kse/src/main/java/org/kse/crypto/provider/PemKeyStoreSpi.java
+++ b/kse/src/main/java/org/kse/crypto/provider/PemKeyStoreSpi.java
@@ -57,7 +57,7 @@ import org.kse.crypto.privatekey.Pkcs8PbeType;
 import org.kse.crypto.privatekey.Pkcs8Util;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.passwordmanager.Password;
-import org.kse.utilities.StringUtils;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.pem.PemInfo;
 import org.kse.utilities.pem.PemUtil;
 
@@ -164,7 +164,6 @@ public class PemKeyStoreSpi extends KeyStoreSpi {
         }
 
         // Build full certificate chain for each key
-        int aliasIndex = 1;
         for (Entry keyEntry : keyEntries) {
 
             X509Certificate leaf = findCertificateForKey(keyEntry.key, x509Certs);
@@ -172,33 +171,16 @@ public class PemKeyStoreSpi extends KeyStoreSpi {
             if (leaf != null) {
                 keyEntry.chain = buildCertificateChain(leaf, bySubject, byIssuer);
 
-                String alias = X509CertUtil.getCertificateAlias(leaf);
-                if (StringUtils.isBlank(alias)) {
-                    alias = "key";
-                }
-                String indexedAlias = alias;
-                while (entries.containsKey(indexedAlias)) {
-                    indexedAlias = alias + aliasIndex++;
-                }
-                entries.put(indexedAlias, keyEntry);
+                entries.put(AliasUtil.uniqueAlias(entries.keySet(), leaf), keyEntry);
             }
         }
 
         // Add standalone certificates
-        aliasIndex = 1;
         for (X509Certificate cert : x509Certs) {
             boolean used = entries.values().stream()
                     .anyMatch(e -> Stream.of(e.chain).anyMatch(c -> c.equals(cert)));
             if (!used) {
-                String alias = X509CertUtil.getCertificateAlias(cert);
-                if (StringUtils.isBlank(alias)) {
-                    alias = "cert";
-                }
-                String indexedAlias = alias;
-                while (entries.containsKey(indexedAlias)) {
-                    indexedAlias = alias + aliasIndex++;
-                }
-                entries.put(indexedAlias, new Entry(cert));
+                entries.put(AliasUtil.uniqueAlias(entries.keySet(), cert), new Entry(cert));
             }
         }
     }

--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -2722,17 +2722,21 @@ public final class KseFrame implements StatusBar {
 
                 // Don't allow for renaming if the key store does not support storing of aliases.
                 jmiKeyPairRename.setEnabled(type.supportsAliases());
-                jmiKeyPairRename.setToolTipText(MessageFormat.format(
-                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
-                        type.friendly()));
                 jmiTrustedCertificateRename.setEnabled(type.supportsAliases());
-                jmiTrustedCertificateRename.setToolTipText(MessageFormat.format(
-                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
-                        type.friendly()));
                 jmiKeyRename.setEnabled(type.supportsAliases());
-                jmiKeyRename.setToolTipText(MessageFormat.format(
-                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
-                        type.friendly()));
+                if (type.supportsAliases()) {
+                    // Clear the tool tip when the rename actions are enabled.
+                    jmiKeyPairRename.setToolTipText(null);
+                    jmiTrustedCertificateRename.setToolTipText(null);
+                    jmiKeyRename.setToolTipText(null);
+                } else {
+                    jmiKeyPairRename.setToolTipText(MessageFormat
+                            .format(res.getString("KseFrame.jmiKeyPairRenameDisabled.tooltip"), type.friendly()));
+                    jmiTrustedCertificateRename.setToolTipText(MessageFormat
+                            .format(res.getString("KseFrame.jmiKeyPairRenameDisabled.tooltip"), type.friendly()));
+                    jmiKeyRename.setToolTipText(MessageFormat
+                            .format(res.getString("KseFrame.jmiKeyPairRenameDisabled.tooltip"), type.friendly()));
+                }
             }
         } else {
             jpmKeyStore.show(jtKeyStore, x, y);

--- a/kse/src/main/java/org/kse/gui/KseFrame.java
+++ b/kse/src/main/java/org/kse/gui/KseFrame.java
@@ -2719,6 +2719,20 @@ public final class KseFrame implements StatusBar {
 
                     jpmKey.show(jtKeyStore, x, y);
                 }
+
+                // Don't allow for renaming if the key store does not support storing of aliases.
+                jmiKeyPairRename.setEnabled(type.supportsAliases());
+                jmiKeyPairRename.setToolTipText(MessageFormat.format(
+                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
+                        type.friendly()));
+                jmiTrustedCertificateRename.setEnabled(type.supportsAliases());
+                jmiTrustedCertificateRename.setToolTipText(MessageFormat.format(
+                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
+                        type.friendly()));
+                jmiKeyRename.setEnabled(type.supportsAliases());
+                jmiKeyRename.setToolTipText(MessageFormat.format(
+                        res.getString("KseFrame.jmiKeyPairRename." + type.supportsAliases() + ".tooltip"),
+                        type.friendly()));
             }
         } else {
             jpmKeyStore.show(jtKeyStore, x, y);

--- a/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ChangeTypeAction.java
@@ -42,6 +42,7 @@ import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -120,9 +121,13 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
                 if (KeyStoreUtil.isTrustedCertificateEntry(alias, currentKeyStore)) {
                     Certificate trustedCertificate = currentKeyStore.getCertificate(alias);
 
-                    if (newKeyStore.containsAlias(alias)) {
-                        showNoticeDuplicateAlias();
-                        alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+                    if (newKeyStoreType.supportsAliases()) {
+                        if (newKeyStore.containsAlias(alias)) {
+                            showNoticeDuplicateAlias();
+                            alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+                        }
+                    } else {
+                        alias = AliasUtil.uniqueAlias(newKeyStore, trustedCertificate);
                     }
 
                     newKeyStore.setCertificateEntry(alias, trustedCertificate);
@@ -189,9 +194,13 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
             }
         }
 
-        if (newKeyStore.containsAlias(alias)) {
-          showNoticeDuplicateAlias();
-          alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+        if (newKeyStoreType.supportsAliases()) {
+            if (newKeyStore.containsAlias(alias)) {
+                showNoticeDuplicateAlias();
+                alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+            }
+        } else {
+            alias = AliasUtil.uniqueAlias(newKeyStore, certificateChain[0]);
         }
 
         currentState.setEntryPassword(alias, password);
@@ -215,20 +224,29 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
             Key secretKey = currentKeyStore.getKey(alias, password.toCharArray());
 
             SecretKeyType secretKeyType = SecretKeyType.resolveJce(secretKey.getAlgorithm());
+            PasswordType passwordType = null;
             if (secretKeyType != null) {
                 if (!newKeyStoreType.supportsKeyType(secretKeyType)) {
                     return showWarnUnsupportedKey();
                 }
             } else {
-                PasswordType passwordType = PasswordType.resolveJce(secretKey.getAlgorithm());
+                passwordType = PasswordType.resolveJce(secretKey.getAlgorithm());
                 if (!newKeyStoreType.supportsPasswordType(passwordType)) {
                     return showWarnUnsupportedKey();
                 }
             }
 
-            if (newKeyStore.containsAlias(alias)) {
-                showNoticeDuplicateAlias();
-                alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+            if (newKeyStoreType.supportsAliases()) {
+                if (newKeyStore.containsAlias(alias)) {
+                    showNoticeDuplicateAlias();
+                    alias = renameAlias(newKeyStoreType.normalizeAlias(alias));
+                }
+            } else {
+                if (secretKeyType != null) {
+                    alias = AliasUtil.uniqueAlias(newKeyStore, secretKeyType);
+                } else {
+                    alias = AliasUtil.uniqueAlias(newKeyStore, passwordType);
+                }
             }
 
             currentState.setEntryPassword(alias, password);
@@ -245,7 +263,7 @@ public class ChangeTypeAction extends KeyStoreExplorerAction implements HistoryA
     private String renameAlias(String alias) {
         int suffix = aliasSuffixes.getOrDefault(alias, 0);
         aliasSuffixes.put(alias, ++suffix);
-        return alias + "-" + String.valueOf(suffix);
+        return alias + " (" + String.valueOf(suffix) + ")";
     }
 
     private boolean showWarnNoECC() {

--- a/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/GenerateKeyPairAction.java
@@ -42,6 +42,7 @@ import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.gui.preferences.data.KeyGenerationSettings;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -177,26 +178,30 @@ public class GenerateKeyPairAction extends KeyStoreExplorerAction implements His
             KseKeyStore keyStore = newState.getKeyStore();
             KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
-            DGetAlias dGetAlias = new DGetAlias(frame,
-                                                res.getString("GenerateKeyPairAction.NewKeyPairEntryAlias.Title"),
-                                                X509CertUtil.getCertificateAlias(certificate));
-            dGetAlias.setLocationRelativeTo(frame);
-            dGetAlias.setVisible(true);
-            alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
+            if (keyStoreType.supportsAliases()) {
+                DGetAlias dGetAlias = new DGetAlias(frame,
+                                                    res.getString("GenerateKeyPairAction.NewKeyPairEntryAlias.Title"),
+                                                    X509CertUtil.getCertificateAlias(certificate));
+                dGetAlias.setLocationRelativeTo(frame);
+                dGetAlias.setVisible(true);
+                alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
-            if (alias == null) {
-                return "";
-            }
-
-            if (keyStore.containsAlias(alias)) {
-                String message = MessageFormat.format(res.getString("GenerateKeyPairAction.OverWriteEntry.message"),
-                                                      alias);
-
-                int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
-                        "GenerateKeyPairAction.NewKeyPairEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
-                if (selected != JOptionPane.YES_OPTION) {
+                if (alias == null) {
                     return "";
                 }
+
+                if (keyStore.containsAlias(alias)) {
+                    String message = MessageFormat.format(res.getString("GenerateKeyPairAction.OverWriteEntry.message"),
+                                                          alias);
+
+                    int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
+                            "GenerateKeyPairAction.NewKeyPairEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return "";
+                    }
+                }
+            } else {
+                alias = AliasUtil.uniqueAlias(keyStore, certificate);
             }
 
             Password password = getNewEntryPassword(activeKeyStoreType,

--- a/kse/src/main/java/org/kse/gui/actions/GenerateSecretKeyAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/GenerateSecretKeyAction.java
@@ -37,6 +37,7 @@ import org.kse.gui.dialogs.DGenerateSecretKey;
 import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -110,26 +111,31 @@ public class GenerateSecretKeyAction extends KeyStoreExplorerAction implements H
             KseKeyStore keyStore = newState.getKeyStore();
             KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
-            DGetAlias dGetAlias = new DGetAlias(frame,
-                                                res.getString("GenerateSecretKeyAction.NewSecretKeyEntryAlias.Title"),
-                                                null);
-            dGetAlias.setLocationRelativeTo(frame);
-            dGetAlias.setVisible(true);
-            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
+            String alias;
+            if (keyStoreType.supportsAliases()) {
+                DGetAlias dGetAlias = new DGetAlias(frame,
+                                                    res.getString("GenerateSecretKeyAction.NewSecretKeyEntryAlias.Title"),
+                                                    null);
+                dGetAlias.setLocationRelativeTo(frame);
+                dGetAlias.setVisible(true);
+                alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
-            if (alias == null) {
-                return;
-            }
-
-            if (keyStore.containsAlias(alias)) {
-                String message = MessageFormat.format(res.getString("GenerateSecretKeyAction.OverWriteEntry.message"),
-                                                      alias);
-
-                int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
-                        "GenerateSecretKeyAction.NewSecretKeyEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
-                if (selected != JOptionPane.YES_OPTION) {
+                if (alias == null) {
                     return;
                 }
+
+                if (keyStore.containsAlias(alias)) {
+                    String message = MessageFormat.format(res.getString("GenerateSecretKeyAction.OverWriteEntry.message"),
+                                                          alias);
+
+                    int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
+                            "GenerateSecretKeyAction.NewSecretKeyEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return;
+                    }
+                }
+            } else {
+                alias = AliasUtil.uniqueAlias(keyStore, secretKeyType);
             }
 
             Password password = getNewEntryPassword(keyStoreType,

--- a/kse/src/main/java/org/kse/gui/actions/ImportKeyPairAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ImportKeyPairAction.java
@@ -36,6 +36,7 @@ import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.dialogs.importexport.DImportKeyPair;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -93,26 +94,31 @@ public class ImportKeyPairAction extends KeyStoreExplorerAction implements Histo
             KseKeyStore keyStore = newState.getKeyStore();
             KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
-            DGetAlias dGetAlias = new DGetAlias(frame, res.getString("ImportKeyPairAction.NewKeyPairEntryAlias.Title"),
-                                                X509CertUtil.getCertificateAlias(certs[0]));
+            String alias;
+            if (keyStoreType.supportsAliases()) {
+                DGetAlias dGetAlias = new DGetAlias(frame, res.getString("ImportKeyPairAction.NewKeyPairEntryAlias.Title"),
+                                                    X509CertUtil.getCertificateAlias(certs[0]));
 
-            dGetAlias.setLocationRelativeTo(frame);
-            dGetAlias.setVisible(true);
-            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
+                dGetAlias.setLocationRelativeTo(frame);
+                dGetAlias.setVisible(true);
+                alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
-            if (alias == null) {
-                return;
-            }
-
-            if (keyStore.containsAlias(alias)) {
-                String message = MessageFormat.format(res.getString("ImportKeyPairAction.OverWriteEntry.message"),
-                                                      alias);
-
-                int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
-                        "ImportKeyPairAction.NewKeyPairEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
-                if (selected != JOptionPane.YES_OPTION) {
+                if (alias == null) {
                     return;
                 }
+
+                if (keyStore.containsAlias(alias)) {
+                    String message = MessageFormat.format(res.getString("ImportKeyPairAction.OverWriteEntry.message"),
+                                                          alias);
+
+                    int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
+                            "ImportKeyPairAction.NewKeyPairEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return;
+                    }
+                }
+            } else {
+                alias = AliasUtil.uniqueAlias(keyStore, certs[0]);
             }
 
             Password password = getNewEntryPassword(keyStoreType,

--- a/kse/src/main/java/org/kse/gui/actions/ImportTrustedCertificateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/ImportTrustedCertificateAction.java
@@ -39,6 +39,7 @@ import org.kse.gui.KseFrame;
 import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.dialogs.DViewCertificate;
 import org.kse.gui.error.DError;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -187,29 +188,34 @@ public class ImportTrustedCertificateAction extends AuthorityCertificatesAction 
                 }
             }
 
-            DGetAlias dGetAlias = new DGetAlias(frame, res.getString(
-                    "ImportTrustedCertificateAction.TrustCertEntryAlias.Title"),
-                                                X509CertUtil.getCertificateAlias(trustCert));
-            dGetAlias.setLocationRelativeTo(frame);
-            dGetAlias.setVisible(true);
-            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
+            String alias;
+            if (keyStoreType.supportsAliases()) {
+                DGetAlias dGetAlias = new DGetAlias(frame, res.getString(
+                                                    "ImportTrustedCertificateAction.TrustCertEntryAlias.Title"),
+                                                    X509CertUtil.getCertificateAlias(trustCert));
+                dGetAlias.setLocationRelativeTo(frame);
+                dGetAlias.setVisible(true);
+                alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
-            if (alias == null) {
-                return;
-            }
-
-            if (keyStore.containsAlias(alias)) {
-                String message = MessageFormat.format(
-                        res.getString("ImportTrustedCertificateAction.OverWriteEntry.message"), alias);
-
-                int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
-                        "ImportTrustedCertificateAction.ImportTrustCert.Title"), JOptionPane.YES_NO_OPTION);
-                if (selected != JOptionPane.YES_OPTION) {
+                if (alias == null) {
                     return;
                 }
 
-                keyStore.deleteEntry(alias);
-                newState.removeEntryPassword(alias);
+                if (keyStore.containsAlias(alias)) {
+                    String message = MessageFormat.format(
+                            res.getString("ImportTrustedCertificateAction.OverWriteEntry.message"), alias);
+
+                    int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
+                            "ImportTrustedCertificateAction.ImportTrustCert.Title"), JOptionPane.YES_NO_OPTION);
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return;
+                    }
+
+                    keyStore.deleteEntry(alias);
+                    newState.removeEntryPassword(alias);
+                }
+            } else {
+                alias = AliasUtil.uniqueAlias(keyStore, trustCert);
             }
 
             keyStore.setCertificateEntry(alias, trustCert);

--- a/kse/src/main/java/org/kse/gui/actions/PasteAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/PasteAction.java
@@ -27,15 +27,19 @@ import java.security.cert.Certificate;
 import java.text.MessageFormat;
 import java.util.List;
 
+import javax.crypto.SecretKey;
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.KeyStroke;
 
 import org.kse.crypto.keystore.KeyStoreType;
 import org.kse.crypto.keystore.KseKeyStore;
+import org.kse.crypto.secretkey.PasswordType;
+import org.kse.crypto.secretkey.SecretKeyType;
 import org.kse.gui.KseFrame;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.buffer.Buffer;
 import org.kse.utilities.buffer.BufferEntry;
 import org.kse.utilities.buffer.KeyBufferEntry;
@@ -114,25 +118,33 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
 
     private boolean pasteEntry(BufferEntry bufferEntry, KseKeyStore keyStore, KeyStoreState newState)
             throws KeyStoreException {
-        String alias = bufferEntry.getName();
+        String alias;
 
-        if (keyStore.containsAlias(alias)) {
-            if (bufferEntry.isCut()) {
-                int selected = JOptionPane.showConfirmDialog(frame, MessageFormat.format(
-                                                                     res.getString("PasteAction.PasteExistsReplace" +
-                                                                                   ".message"), alias),
-                                                             res.getString("PasteAction.Paste.Title"),
-                                                             JOptionPane.YES_NO_OPTION);
+        // Only handle the cut if the key store type supports aliases
+        if (newState.getType().supportsAliases()) {
+            alias = bufferEntry.getName();
 
-                if (selected != JOptionPane.YES_OPTION) {
-                    return false;
+            if (keyStore.containsAlias(alias)) {
+                if (bufferEntry.isCut()) {
+                    int selected = JOptionPane.showConfirmDialog(frame, MessageFormat.format(
+                            res.getString("PasteAction.PasteExistsReplace" +
+                                    ".message"), alias),
+                            res.getString("PasteAction.Paste.Title"),
+                            JOptionPane.YES_NO_OPTION);
+
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return false;
+                    }
+
+                    keyStore.deleteEntry(alias);
+                    newState.removeEntryPassword(alias);
+                } else {
+                    alias = AliasUtil.uniqueAlias(keyStore, alias);
                 }
-
-                keyStore.deleteEntry(alias);
-                newState.removeEntryPassword(alias);
-            } else {
-                alias = getUniqueEntryName(alias, keyStore);
             }
+        } else {
+            // Wipe out the incoming alias since it must be generated from the entry.
+            alias = null;
         }
 
         if (bufferEntry instanceof KeyBufferEntry) {
@@ -153,6 +165,16 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
 
             Password password = keyBufferEntry.getPassword();
 
+            if (alias == null && key instanceof SecretKey) {
+                SecretKeyType secretKeyType = SecretKeyType.resolveJce(key.getAlgorithm());
+                if (secretKeyType != null) {
+                    alias = AliasUtil.uniqueAlias(keyStore, secretKeyType);
+                } else {
+                    PasswordType passwordType = PasswordType.resolveJce(key.getAlgorithm());
+                    alias = AliasUtil.uniqueAlias(keyStore, passwordType);
+                }
+            }
+
             keyStore.setKeyEntry(alias, key, password.toCharArray(), null);
 
             newState.setEntryPassword(alias, password);
@@ -164,11 +186,19 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
 
             Certificate[] certificateChain = keyPairBufferEntry.getCertificateChain();
 
+            if (alias == null) {
+                alias = AliasUtil.uniqueAlias(keyStore, certificateChain[0]);
+            }
+
             keyStore.setKeyEntry(alias, privateKey, password.toCharArray(), certificateChain);
 
             newState.setEntryPassword(alias, password);
         } else {
             TrustedCertificateBufferEntry certBufferEntry = (TrustedCertificateBufferEntry) bufferEntry;
+
+            if (alias == null) {
+                alias = AliasUtil.uniqueAlias(keyStore, certBufferEntry.getTrustedCertificate());
+            }
 
             keyStore.setCertificateEntry(alias, certBufferEntry.getTrustedCertificate());
         }
@@ -178,19 +208,5 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
         }
 
         return true;
-    }
-
-    private String getUniqueEntryName(String name, KseKeyStore keyStore) throws KeyStoreException {
-        // Get unique KeyStore entry name based on the one supplied, ie *
-        // "<name> (n)" where n is a
-        // number.
-        int i = 1;
-        while (true) {
-            String tryName = MessageFormat.format("{0} ({1})", name, i);
-            if (!keyStore.containsAlias(tryName)) {
-                return tryName;
-            }
-            i++;
-        }
     }
 }

--- a/kse/src/main/java/org/kse/gui/actions/PasteAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/PasteAction.java
@@ -126,11 +126,9 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
 
             if (keyStore.containsAlias(alias)) {
                 if (bufferEntry.isCut()) {
-                    int selected = JOptionPane.showConfirmDialog(frame, MessageFormat.format(
-                            res.getString("PasteAction.PasteExistsReplace" +
-                                    ".message"), alias),
-                            res.getString("PasteAction.Paste.Title"),
-                            JOptionPane.YES_NO_OPTION);
+                    int selected = JOptionPane.showConfirmDialog(frame,
+                            MessageFormat.format(res.getString("PasteAction.PasteExistsReplace.message"), alias),
+                            res.getString("PasteAction.Paste.Title"), JOptionPane.YES_NO_OPTION);
 
                     if (selected != JOptionPane.YES_OPTION) {
                         return false;
@@ -151,10 +149,10 @@ public class PasteAction extends KeyStoreExplorerAction implements HistoryAction
             KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
             if (!keyStoreType.supportsKeyEntries()) {
+                String friendly = keyStoreType.friendly();
                 JOptionPane.showMessageDialog(frame,
-                                              MessageFormat.format(res.getString("PasteAction.NoPasteKeyEntry.message"),
-                                                                   keyStoreType.friendly()),
-                                              res.getString("PasteAction.Paste.Title"), JOptionPane.WARNING_MESSAGE);
+                        MessageFormat.format(res.getString("PasteAction.NoPasteKeyEntry.message"), friendly),
+                        res.getString("PasteAction.Paste.Title"), JOptionPane.WARNING_MESSAGE);
 
                 return false;
             }

--- a/kse/src/main/java/org/kse/gui/actions/StorePassphraseAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/StorePassphraseAction.java
@@ -38,6 +38,7 @@ import org.kse.gui.dialogs.DGetAlias;
 import org.kse.gui.dialogs.DStorePassphrase;
 import org.kse.gui.error.DError;
 import org.kse.gui.passwordmanager.Password;
+import org.kse.utilities.AliasUtil;
 import org.kse.utilities.history.HistoryAction;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
@@ -110,26 +111,31 @@ public class StorePassphraseAction extends KeyStoreExplorerAction implements His
             KseKeyStore keyStore = newState.getKeyStore();
             KeyStoreType keyStoreType = KeyStoreType.resolveJce(keyStore.getType());
 
-            DGetAlias dGetAlias = new DGetAlias(frame,
-                                                res.getString("StorePassphraseAction.NewPassphraseEntryAlias.Title"),
-                                                null);
-            dGetAlias.setLocationRelativeTo(frame);
-            dGetAlias.setVisible(true);
-            String alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
+            String alias;
+            if (keyStoreType.supportsAliases()) {
+                DGetAlias dGetAlias = new DGetAlias(frame,
+                                                    res.getString("StorePassphraseAction.NewPassphraseEntryAlias.Title"),
+                                                    null);
+                dGetAlias.setLocationRelativeTo(frame);
+                dGetAlias.setVisible(true);
+                alias = keyStoreType.normalizeAlias(dGetAlias.getAlias());
 
-            if (alias == null) {
-                return;
-            }
-
-            if (keyStore.containsAlias(alias)) {
-                String message = MessageFormat.format(res.getString("StorePassphraseAction.OverWriteEntry.message"),
-                                                      alias);
-
-                int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
-                        "StorePassphraseAction.NewPassphraseEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
-                if (selected != JOptionPane.YES_OPTION) {
+                if (alias == null) {
                     return;
                 }
+
+                if (keyStore.containsAlias(alias)) {
+                    String message = MessageFormat.format(res.getString("StorePassphraseAction.OverWriteEntry.message"),
+                                                          alias);
+
+                    int selected = JOptionPane.showConfirmDialog(frame, message, res.getString(
+                            "StorePassphraseAction.NewPassphraseEntryAlias.Title"), JOptionPane.YES_NO_OPTION);
+                    if (selected != JOptionPane.YES_OPTION) {
+                        return;
+                    }
+                }
+            } else {
+                alias = AliasUtil.uniqueAlias(keyStore, passphraseType.friendly());
             }
 
             Password password = getNewEntryPassword(keyStoreType,

--- a/kse/src/main/java/org/kse/utilities/AliasUtil.java
+++ b/kse/src/main/java/org/kse/utilities/AliasUtil.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.kse.utilities;
+
+import java.security.KeyStoreException;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.kse.crypto.CryptoException;
+import org.kse.crypto.keystore.KseKeyStore;
+import org.kse.crypto.secretkey.PasswordType;
+import org.kse.crypto.secretkey.SecretKeyType;
+import org.kse.crypto.x509.X509CertUtil;
+
+/**
+ * Utilities for creating unique alias names.
+ */
+public final class AliasUtil {
+
+    // Utility pattern
+    private AliasUtil() {
+    }
+
+    /**
+     * Generates an unique alias in a key store for a certificate.
+     *
+     * @param keyStore The key store
+     * @param cert     The certificate
+     * @return An unique alias
+     */
+    public static String uniqueAlias(KseKeyStore keyStore, Certificate cert) {
+        try {
+            X509Certificate x509Cert = X509CertUtil.convertCertificate(cert);
+            return uniqueAlias(keyStore, x509Cert);
+        } catch (CryptoException e) {
+            return uniqueAlias(keyStore, (String) null);
+        }
+    }
+
+    /**
+     * Generates an unique alias in a key store for a certificate.
+     *
+     * @param keyStore The key store
+     * @param cert     The certificate
+     * @return An unique alias
+     */
+    public static String uniqueAlias(KseKeyStore keyStore, X509Certificate cert) {
+        return uniqueAlias(keyStore, X509CertUtil.getCertificateAlias(cert));
+    }
+
+    /**
+     * Generates an unique alias in a key store for a secret key.
+     *
+     * @param keyStore      The key store
+     * @param secretKeyType The secret key type
+     * @return An unique alias
+     */
+    public static String uniqueAlias(KseKeyStore keyStore, SecretKeyType secretKeyType) {
+        return uniqueAlias(keyStore, secretKeyType != null ? secretKeyType.friendly() : null);
+    }
+
+    /**
+     * Generates an unique alias in a key store for a passphrase.
+     *
+     * @param keyStore     The key store
+     * @param passwordType The secret key type
+     * @return An unique alias
+     */
+    public static String uniqueAlias(KseKeyStore keyStore, PasswordType passwordType) {
+        return uniqueAlias(keyStore, passwordType != null ? passwordType.friendly() : null);
+    }
+
+    /**
+     * Makes an unique alias in a key store.
+     *
+     * @param keyStore The key store
+     * @param alias    The alias to make unique
+     * @return An unique alias
+     */
+    public static String uniqueAlias(KseKeyStore keyStore, String alias) {
+        return uniqueAlias(t -> {
+            try {
+                return keyStore.containsAlias(t);
+            } catch (KeyStoreException e) {
+                return false;
+            }
+        }, alias);
+    }
+
+    /**
+     * Generates an unique alias in a entry set for a certificate.
+     *
+     * @param aliases The set of aliases
+     * @param cert    The certificate
+     * @return An unique alias
+     */
+    public static String uniqueAlias(Set<String> aliases, X509Certificate cert) {
+        return uniqueAlias(aliases::contains, X509CertUtil.getCertificateAlias(cert));
+    }
+
+    private static String uniqueAlias(Function<String, Boolean> matcher, String alias) {
+        if (StringUtils.isBlank(alias)) {
+            alias = "entry";
+        }
+
+        int index = 1;
+        String proposedAlias = alias;
+        while (matcher.apply(proposedAlias)) {
+            proposedAlias = alias + " (" + index++ + ")";
+        }
+
+        return proposedAlias;
+    }
+}

--- a/kse/src/main/resources/org/kse/gui/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/resources.properties
@@ -163,9 +163,7 @@ KseFrame.jmiImportKeyPair.mnemonic              = m
 KseFrame.jmiImportTrustedCertificate.mnemonic   = i
 KseFrame.jmiJars.mnemonic                       = j
 KseFrame.jmiKeyPairGenerateCsr.tooltip          = Cannot generate a CSR for ML-KEM since a signature is required for proof of possession.
-KseFrame.jmiKeyPairRename.false.tooltip         = Cannot rename the entry. The {0} key store type does not support user chosen aliases.
-# Used to clear the "false" tooltip when the rename action is enabled. A tooltip is not necessary when the rename action is enabled.
-KseFrame.jmiKeyPairRename.true.tooltip          =
+KseFrame.jmiKeyPairRenameDisabled.tooltip       = Cannot rename the entry. The {0} key store type does not support user chosen aliases.
 KseFrame.jmiNew.mnemonic                        = n
 KseFrame.jmiOpen.mnemonic                       = o
 KseFrame.jmiOpenAppleKeychainKeystore.mnemonic  = a

--- a/kse/src/main/resources/org/kse/gui/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/resources.properties
@@ -163,6 +163,9 @@ KseFrame.jmiImportKeyPair.mnemonic              = m
 KseFrame.jmiImportTrustedCertificate.mnemonic   = i
 KseFrame.jmiJars.mnemonic                       = j
 KseFrame.jmiKeyPairGenerateCsr.tooltip          = Cannot generate a CSR for ML-KEM since a signature is required for proof of possession.
+KseFrame.jmiKeyPairRename.false.tooltip         = Cannot rename the entry. The {0} key store type does not support user chosen aliases.
+# Used to clear the "false" tooltip when the rename action is enabled. A tooltip is not necessary when the rename action is enabled.
+KseFrame.jmiKeyPairRename.true.tooltip          =
 KseFrame.jmiNew.mnemonic                        = n
 KseFrame.jmiOpen.mnemonic                       = o
 KseFrame.jmiOpenAppleKeychainKeystore.mnemonic  = a


### PR DESCRIPTION
This PR closes #786. The changes are:
* Adds a method to KeyStoreType to indicate if the key store type supports aliases. The PEM key store type is the only one that does not support aliases.
* When a key store does not support aliases:
  * Aliases cannot be renamed
  * The generate and import actions do not ask for an alias
  * Changing a key store type to PEM will discard the aliases and generate new ones consistent with opening the PEM key store
  * Pasting entries into a PEM key store will always add new entries (never overwrite existing ones -- even for cutting) discarding the original alias and generating new ones consistent with opening the PEM key store.
* Refactored existing code to use the new AliasUtil class.