### PR TITLE
Add support Ed448 support for Sign JWT

### DIFF
--- a/kse/build.gradle.kts
+++ b/kse/build.gradle.kts
@@ -130,7 +130,7 @@ dependencies {
     implementation("com.formdev:flatlaf-extras:3.7") {
         exclude(group = "com.formdev", module = "flatlaf")
     }
-    implementation("com.nimbusds:nimbus-jose-jwt:10.6") {
+    implementation("com.nimbusds:nimbus-jose-jwt:10.8") {
         exclude(group = "com.google.crypto.tink", module = "tink")
     }
 

--- a/kse/src/main/java/org/kse/crypto/signing/BcEd448Signer.java
+++ b/kse/src/main/java/org/kse/crypto/signing/BcEd448Signer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.crypto.signing;
+
+import java.util.Set;
+
+import org.bouncycastle.crypto.params.Ed448PrivateKeyParameters;
+import org.bouncycastle.crypto.signers.Ed448Signer;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.impl.BaseJWSProvider;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
+
+/**
+ * Ed448 signer backed by Bouncy Castle.
+ */
+public class BcEd448Signer extends BaseJWSProvider implements JWSSigner {
+
+    private static final Set<JWSAlgorithm> SUPPORTED = Set.of(JWSAlgorithm.Ed448, JWSAlgorithm.EdDSA);
+    private static final byte[] NO_CONTEXT = new byte[0];
+
+    private final Ed448PrivateKeyParameters privateKeyParams;
+
+    public BcEd448Signer(OctetKeyPair privateKey) throws JOSEException {
+        super(SUPPORTED);
+        if (!privateKey.isPrivate()) {
+            throw new JOSEException("OctetKeyPair must contain a private key (d)");
+        }
+        privateKeyParams = new Ed448PrivateKeyParameters(privateKey.getDecodedD(), 0);
+    }
+
+    @Override
+    public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
+        JWSAlgorithm alg = header.getAlgorithm();
+        if (!SUPPORTED.contains(alg)) {
+            throw new JOSEException("Unsupported algorithm: " + alg);
+        }
+        try {
+            // RFC 8037/9864 do not allow for Ed448 with context
+            Ed448Signer signer = new Ed448Signer(NO_CONTEXT);
+            signer.init(true, privateKeyParams);
+            signer.update(signingInput, 0, signingInput.length);
+            return Base64URL.encode(signer.generateSignature());
+        } catch (Exception e) {
+            throw new JOSEException("Ed448 signing failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/kse/src/main/java/org/kse/crypto/signing/BcEd448Verifier.java
+++ b/kse/src/main/java/org/kse/crypto/signing/BcEd448Verifier.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.crypto.signing;
+
+import java.util.Set;
+
+import org.bouncycastle.crypto.params.Ed448PublicKeyParameters;
+import org.bouncycastle.crypto.signers.Ed448Signer;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.impl.BaseJWSProvider;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.util.Base64URL;
+
+/**
+ * Ed448 verifier backed by Bouncy Castle.
+ */
+public class BcEd448Verifier extends BaseJWSProvider implements JWSVerifier {
+
+    private static final Set<JWSAlgorithm> SUPPORTED = Set.of(JWSAlgorithm.Ed448, JWSAlgorithm.EdDSA);
+    private static final byte[] NO_CONTEXT = new byte[0];
+
+    private final Ed448PublicKeyParameters publicKeyParams;
+
+    public BcEd448Verifier(OctetKeyPair publicKey) throws JOSEException {
+        super(SUPPORTED);
+        publicKeyParams = new Ed448PublicKeyParameters(publicKey.getDecodedX(), 0);
+    }
+
+    @Override
+    public boolean verify(JWSHeader header, byte[] signingInput, Base64URL signature) throws JOSEException {
+        JWSAlgorithm alg = header.getAlgorithm();
+        if (!SUPPORTED.contains(alg)) {
+            throw new JOSEException("Unsupported algorithm: " + alg);
+        }
+        try {
+            // RFC 8037/9864 do not allow for Ed448 with context
+            Ed448Signer verifier = new Ed448Signer(NO_CONTEXT);
+            verifier.init(false, publicKeyParams);
+            verifier.update(signingInput, 0, signingInput.length);
+            return verifier.verifySignature(signature.decode());
+        } catch (Exception e) {
+            throw new JOSEException("Ed448 verification failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/kse/src/main/java/org/kse/crypto/signing/JwsSigner.java
+++ b/kse/src/main/java/org/kse/crypto/signing/JwsSigner.java
@@ -20,12 +20,17 @@
 
 package org.kse.crypto.signing;
 
+import java.io.IOException;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.security.interfaces.EdECPrivateKey;
 
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed448PrivateKeyParameters;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
+import org.kse.crypto.ecc.EdDSACurves;
 
+import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
@@ -64,10 +69,16 @@ public class JwsSigner {
             signer = new RSASSASigner(privateKey);
         } else if (JWSAlgorithm.Family.EC.contains(signatureAlgorithm)) {
             signer = new ECDSASigner(privateKey, curve);
-        } else if (JWSAlgorithm.Ed25519 == signatureAlgorithm || JWSAlgorithm.EdDSA == signatureAlgorithm) {
-            var params = (Ed25519PrivateKeyParameters) PrivateKeyFactory.createKey(privateKey.getEncoded());
-            OctetKeyPair okp = buildOctectKeyAPair(params);
-            signer = new BcEd25519Signer(okp);
+        } else if (JWSAlgorithm.Ed25519 == signatureAlgorithm) {
+            signer = newEd25519Signer(privateKey);
+        } else if (JWSAlgorithm.Ed448 == signatureAlgorithm) {
+            signer = newEd448Signer(privateKey);
+        } else if (JWSAlgorithm.EdDSA == signatureAlgorithm) {
+            if (EdDSACurves.ED448.jce().equals(((EdECPrivateKey) privateKey).getParams().getName())) {
+                signer = newEd448Signer(privateKey);
+            } else {
+                signer = newEd25519Signer(privateKey);
+            }
         }
 
         if (provider != null && signer != null) {
@@ -80,9 +91,27 @@ public class JwsSigner {
         return signedJWT;
     }
 
+    private static JWSSigner newEd25519Signer(PrivateKey privateKey) throws IOException, JOSEException {
+        var params = (Ed25519PrivateKeyParameters) PrivateKeyFactory.createKey(privateKey.getEncoded());
+        OctetKeyPair okp = buildOctectKeyAPair(params);
+        return new BcEd25519Signer(okp);
+    }
+
+    private static JWSSigner newEd448Signer(PrivateKey privateKey) throws IOException, JOSEException {
+        var params = (Ed448PrivateKeyParameters) PrivateKeyFactory.createKey(privateKey.getEncoded());
+        OctetKeyPair okp = buildOctectKeyAPair(params);
+        return new BcEd448Signer(okp);
+    }
+
     private static OctetKeyPair buildOctectKeyAPair(Ed25519PrivateKeyParameters params) {
         Base64URL base64EncodedPubKey = Base64URL.encode(params.generatePublicKey().getEncoded());
         Base64URL base64EncodedParams = Base64URL.encode(params.getEncoded());
         return new OctetKeyPair.Builder(Curve.Ed25519, base64EncodedPubKey).d(base64EncodedParams).build();
+    }
+
+    private static OctetKeyPair buildOctectKeyAPair(Ed448PrivateKeyParameters params) {
+        Base64URL base64EncodedPubKey = Base64URL.encode(params.generatePublicKey().getEncoded());
+        Base64URL base64EncodedParams = Base64URL.encode(params.getEncoded());
+        return new OctetKeyPair.Builder(Curve.Ed448, base64EncodedPubKey).d(base64EncodedParams).build();
     }
 }

--- a/kse/src/main/java/org/kse/gui/actions/SignJwtAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/SignJwtAction.java
@@ -29,9 +29,6 @@ import java.security.interfaces.ECPublicKey;
 
 import javax.swing.ImageIcon;
 
-import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
-import org.bouncycastle.crypto.util.PrivateKeyFactory;
-import org.kse.crypto.ecc.EdDSACurves;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.crypto.keystore.KseKeyStore;
@@ -46,15 +43,7 @@ import org.kse.gui.passwordmanager.Password;
 import org.kse.utilities.history.KeyStoreHistory;
 import org.kse.utilities.history.KeyStoreState;
 
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import org.kse.crypto.signing.BcEd25519Signer;
-import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.OctetKeyPair;
-import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTClaimsSet.Builder;
 import com.nimbusds.jwt.SignedJWT;
@@ -145,11 +134,10 @@ public class SignJwtAction extends KeyStoreExplorerAction {
             // Only the standard EC curves are supported (P-256, P-384, P-521)
             isSupported = Curve.forECParameterSpec(((ECPublicKey) publicKey).getParams()) != null;
         }
-        // Nimbus-JOSE does not support signing a JWT with Ed448, ML-DSA, SLH-DSA.
-        boolean isEd448 = EdDSACurves.ED448.jce().equals(publicKey.getAlgorithm());
+        // Nimbus-JOSE does not support signing a JWT with ML-DSA, SLH-DSA.
         boolean isMlDSA = KeyPairType.isMlDSA(KeyPairUtil.getKeyPairType(publicKey));
         boolean isSlhDsa = KeyPairType.isSlhDsa(KeyPairUtil.getKeyPairType(publicKey));
-        isSupported = isSupported && !isEd448 && !isMlDSA && !isSlhDsa;
+        isSupported = isSupported && !isMlDSA && !isSlhDsa;
         if (!isSupported) {
             tooltip = res.getString("SignJwtAction.NotSupported.message");
         }

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewJwt.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewJwt.java
@@ -70,6 +70,8 @@ import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import org.kse.crypto.signing.BcEd25519Verifier;
+import org.kse.crypto.signing.BcEd448Verifier;
+
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.OctetKeyPair;
@@ -310,15 +312,15 @@ public class DViewJwt extends JEscDialog {
                 verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
             // Works for Java 15+ since OpenSslPubUtil uses the BC provider for loading the key
             } else if (publicKey instanceof EdDSAPublicKey) {
-                // Prevent exceptions in case an Ed448 key is used. There's no JWSVerifier for Ed448 keys.
                 if (EdDSACurves.ED448.jce().equals(publicKey.getAlgorithm())) {
-                    JOptionPane.showMessageDialog(this, res.getString("DViewJwt.InvalidPublicKey.message"),
-                            res.getString("DViewJwt.Verify.Title"), JOptionPane.ERROR_MESSAGE);
-                    return;
+                    OctetKeyPair okp = new OctetKeyPair.Builder(Curve.Ed448,
+                            Base64URL.encode(((EdDSAPublicKey) publicKey).getPointEncoding())).build();
+                    verifier = new BcEd448Verifier(okp);
+                } else {
+                    OctetKeyPair okp = new OctetKeyPair.Builder(Curve.Ed25519,
+                            Base64URL.encode(((EdDSAPublicKey) publicKey).getPointEncoding())).build();
+                    verifier = new BcEd25519Verifier(okp);
                 }
-                OctetKeyPair okp = new OctetKeyPair.Builder(Curve.Ed25519,
-                        Base64URL.encode(((EdDSAPublicKey) publicKey).getPointEncoding())).build();
-                verifier = new BcEd25519Verifier(okp);
             } else {
                 JOptionPane.showMessageDialog(this, res.getString("DViewJwt.InvalidPublicKey.message"),
                         res.getString("DViewJwt.Verify.Title"), JOptionPane.ERROR_MESSAGE);

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJwt.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignJwt.java
@@ -29,6 +29,7 @@ import java.awt.event.WindowEvent;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.EdECPrivateKey;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -47,6 +48,7 @@ import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
 import org.kse.KSE;
+import org.kse.crypto.ecc.EdDSACurves;
 import org.kse.crypto.keypair.KeyPairType;
 import org.kse.crypto.keypair.KeyPairUtil;
 import org.kse.gui.PlatformUtil;
@@ -160,9 +162,17 @@ public class DSignJwt extends JEscDialog {
             jcbSignatureAlgorithm.addItem(JWSAlgorithm.PS256);
             jcbSignatureAlgorithm.addItem(JWSAlgorithm.PS384);
             jcbSignatureAlgorithm.addItem(JWSAlgorithm.PS512);
-        } else if (KeyPairType.ED25519 == signKeyPairType || KeyPairType.EDDSA == signKeyPairType) {
-            jcbSignatureAlgorithm.addItem(JWSAlgorithm.EdDSA);
-            jcbSignatureAlgorithm.addItem(JWSAlgorithm.Ed25519);
+        } else if (KeyPairType.EDDSA == signKeyPairType) {
+            if (EdDSACurves.ED25519.jce().equals(((EdECPrivateKey) signPrivateKey).getParams().getName())) {
+                // EdDSA is default for compatibility though deprecated in RFC 9864.
+                jcbSignatureAlgorithm.addItem(JWSAlgorithm.EdDSA);
+                jcbSignatureAlgorithm.addItem(JWSAlgorithm.Ed25519);
+            } else {
+                // EdDSA is last since it is deprecated in RFC 9864 and some implementations
+                // assume that EdDSA is only Ed25519.
+                jcbSignatureAlgorithm.addItem(JWSAlgorithm.Ed448);
+                jcbSignatureAlgorithm.addItem(JWSAlgorithm.EdDSA);
+            }
         }
         jcbSignatureAlgorithm.setToolTipText(res.getString("DSignJwt.jcbSignatureAlgorithm.tooltip"));
 

--- a/kse/src/test/java/org/kse/crypto/signing/JwsSignerTest.java
+++ b/kse/src/test/java/org/kse/crypto/signing/JwsSignerTest.java
@@ -28,6 +28,7 @@ import java.util.Date;
 import java.util.stream.Stream;
 
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
+import org.bouncycastle.crypto.params.Ed448PrivateKeyParameters;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -64,6 +65,7 @@ public class JwsSignerTest extends CryptoTestsBase {
     private static KeyPair ecP384KeyPair;
     private static KeyPair ecP521KeyPair;
     private static KeyPair ed25519KeyPair;
+    private static KeyPair ed448KeyPair;
 
     @BeforeAll
     static void setUpKeys() throws Exception {
@@ -72,6 +74,7 @@ public class JwsSignerTest extends CryptoTestsBase {
         ecP384KeyPair = KeyPairUtil.generateECKeyPair("P-384", KSE.BC);
         ecP521KeyPair = KeyPairUtil.generateECKeyPair("P-521", KSE.BC);
         ed25519KeyPair = KeyPairUtil.generateECKeyPair("Ed25519", KSE.BC);
+        ed448KeyPair = KeyPairUtil.generateECKeyPair("Ed448", KSE.BC);
     }
 
     // -----------------------------------------------------------------------
@@ -113,6 +116,14 @@ public class JwsSignerTest extends CryptoTestsBase {
         Base64URL encodedPub = Base64URL.encode(params.generatePublicKey().getEncoded());
         OctetKeyPair publicOkp = new OctetKeyPair.Builder(Curve.Ed25519, encodedPub).build();
         return new BcEd25519Verifier(publicOkp);
+    }
+
+    private static BcEd448Verifier buildEd448Verifier() throws Exception {
+        Ed448PrivateKeyParameters params =
+                (Ed448PrivateKeyParameters) PrivateKeyFactory.createKey(ed448KeyPair.getPrivate().getEncoded());
+        Base64URL encodedPub = Base64URL.encode(params.generatePublicKey().getEncoded());
+        OctetKeyPair publicOkp = new OctetKeyPair.Builder(Curve.Ed448, encodedPub).build();
+        return new BcEd448Verifier(publicOkp);
     }
 
     /**
@@ -248,7 +259,7 @@ public class JwsSignerTest extends CryptoTestsBase {
         );
     }
 
-    @ParameterizedTest(name = "EdDSA sign+verify – {0} (no provider)")
+    @ParameterizedTest(name = "EdDSA sign+verify - {0} (no provider)")
     @MethodSource("edDsaAlgorithms")
     void testSignJwtWithEdDsaAlgorithm(JWSAlgorithm algorithm) throws Exception {
         JWTClaimsSet claimsSet = buildClaimsSet();
@@ -267,7 +278,7 @@ public class JwsSignerTest extends CryptoTestsBase {
         assertRoundTripVerification(signedJWT, verifier);
     }
 
-    @ParameterizedTest(name = "EdDSA sign+verify – {0} (with BC provider)")
+    @ParameterizedTest(name = "EdDSA sign+verify - {0} (with BC provider)")
     @MethodSource("edDsaAlgorithms")
     void testSignJwtWithEdDsaAlgorithmAndBcProvider(JWSAlgorithm algorithm) throws Exception {
         JWTClaimsSet claimsSet = buildClaimsSet();
@@ -280,6 +291,54 @@ public class JwsSignerTest extends CryptoTestsBase {
         assertThat(signedJWT.getHeader().getAlgorithm()).isEqualTo(algorithm);
 
         BcEd25519Verifier verifier = buildEd25519Verifier();
+        assertThat(signedJWT.verify(verifier)).isTrue();
+    }
+
+    // -----------------------------------------------------------------------
+    // EdDSA - Ed448 / EdDSA algorithm identifiers
+    // RFC 8037 uses "EdDSA" while the RFC 9864 specifies "Ed448" and deprecates "EdDSA".
+    // Both must be accepted by JwsSigner.
+    // -----------------------------------------------------------------------
+
+    static Stream<Arguments> ed448Algorithms() {
+        return Stream.of(
+                Arguments.of(JWSAlgorithm.Ed448),
+                Arguments.of(JWSAlgorithm.EdDSA)
+        );
+    }
+
+    @ParameterizedTest(name = "Ed448 sign+verify - {0} (no provider)")
+    @MethodSource("ed448Algorithms")
+    void testSignJwtWithEd448Algorithm(JWSAlgorithm algorithm) throws Exception {
+        JWTClaimsSet claimsSet = buildClaimsSet();
+
+        SignedJWT signedJWT = JwsSigner.signJwt(algorithm, null, claimsSet,
+                ed448KeyPair.getPrivate(), null);
+
+        assertThat(signedJWT).isNotNull();
+        assertThat(signedJWT.getState()).isEqualTo(JWSObject.State.SIGNED);
+        assertThat(signedJWT.getHeader().getAlgorithm()).isEqualTo(algorithm);
+        assertThat(signedJWT.getHeader().getKeyID()).isNull();
+
+        BcEd448Verifier verifier = buildEd448Verifier();
+        assertThat(signedJWT.verify(verifier)).isTrue();
+        assertClaimsPreserved(signedJWT, claimsSet);
+        assertRoundTripVerification(signedJWT, verifier);
+    }
+
+    @ParameterizedTest(name = "Ed448 sign+verify - {0} (with BC provider)")
+    @MethodSource("ed448Algorithms")
+    void testSignJwtWithEd448AlgorithmAndBcProvider(JWSAlgorithm algorithm) throws Exception {
+        JWTClaimsSet claimsSet = buildClaimsSet();
+
+        SignedJWT signedJWT = JwsSigner.signJwt(algorithm, null, claimsSet,
+                ed448KeyPair.getPrivate(), KSE.BC);
+
+        assertThat(signedJWT).isNotNull();
+        assertThat(signedJWT.getState()).isEqualTo(JWSObject.State.SIGNED);
+        assertThat(signedJWT.getHeader().getAlgorithm()).isEqualTo(algorithm);
+
+        BcEd448Verifier verifier = buildEd448Verifier();
         assertThat(signedJWT.verify(verifier)).isTrue();
     }
 


### PR DESCRIPTION
After seeing that 29649c5 used BC for handling the Ed25519 sign/verify operations, extending to add support for Ed448 is very straightforward. This PR enables the Sign JWT action for Ed448 keys.

Both Ed448 and EdDSA signature algorithms are allowed for Ed448 signing. EdDSA is deprecated as noted in 29649c5 so it is not the default selection.

<img width="437" height="493" alt="image" src="https://github.com/user-attachments/assets/236e4213-19f4-4136-a054-3a3d023b4d78" />

Updated the unit tests to test Ed448 and EdDSA (Ed448 key).