### PR TITLE
Fix workflow problem when setting a new passphrase.

### DIFF
--- a/kse/src/main/java/org/kse/gui/dialogs/DStorePassphrase.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DStorePassphrase.java
@@ -75,7 +75,6 @@ public class DStorePassphrase extends JEscDialog {
     private KeyStoreType keystoreType;
     private PasswordType passwordType;
 
-    private Password passphrase;
     private boolean success = false;
 
     /**
@@ -177,7 +176,7 @@ public class DStorePassphrase extends JEscDialog {
      * @return The passphrase as a Password.
      */
     public Password getPassphrase() {
-        return passphrase;
+        return new Password(jpfPassword.getPassword());
     }
 
     /**
@@ -190,8 +189,13 @@ public class DStorePassphrase extends JEscDialog {
     }
 
     private void setPassPressed() {
+        Password passphrase = null;
+        if (jpfPassword.getPassword() != null && jpfPassword.getPassword().length > 0) {
+            passphrase = new Password(jpfPassword.getPassword());
+        }
+
         DGetNewPassword dPassphrase = new DGetNewPassword((JFrame) getParent(),
-                res.getString("DStorePassphrase.NewPassphrase.Title"), preferences);
+                res.getString("DStorePassphrase.NewPassphrase.Title"), preferences, passphrase);
         dPassphrase.setLocationRelativeTo(this);
         dPassphrase.setVisible(true);
 
@@ -202,7 +206,7 @@ public class DStorePassphrase extends JEscDialog {
     }
 
     private void okPressed() {
-        if (passphrase == null) {
+        if (jpfPassword.getPassword() == null || jpfPassword.getPassword().length == 0) {
             JOptionPane.showMessageDialog(getParent(),
                     res.getString("DStorePassphrase.NoPassphrase.message"),
                     res.getString("DStorePassphrase.Title"), JOptionPane.WARNING_MESSAGE);

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPassword.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPassword.java
@@ -45,6 +45,7 @@ import org.kse.crypto.secretkey.PasswordType;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.gui.components.JEscDialog;
 import org.kse.gui.password.DChangePassword;
+import org.kse.gui.password.DGetNewPassword;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.gui.preferences.PreferencesManager;
 import org.kse.gui.preferences.data.KsePreferences;
@@ -187,11 +188,12 @@ public class DViewPassword extends JEscDialog {
 
     private void updatePressed() {
         Password password = new Password(jpfPassword.getPassword());
-        DChangePassword dChangePassword = new DChangePassword(this, DEFAULT_MODALITY_TYPE, password, preferences);
+        DGetNewPassword dChangePassword = new DGetNewPassword(this, res.getString("DViewPassword.NewPassphrase.title"),
+                preferences, password);
         dChangePassword.setLocationRelativeTo(this);
         dChangePassword.setVisible(true);
 
-        newPassword = dChangePassword.getNewPassword();
+        newPassword = dChangePassword.getPassword();
         if (newPassword != null) {
             jpfPassword.setText(new String(newPassword.toCharArray()));
         }

--- a/kse/src/main/java/org/kse/gui/password/DGetNewPassword.java
+++ b/kse/src/main/java/org/kse/gui/password/DGetNewPassword.java
@@ -23,7 +23,7 @@ import static org.kse.gui.password.PasswordDialogHelper.createPasswordInputField
 import static org.kse.gui.password.PasswordDialogHelper.preFillPasswordFields;
 
 import java.awt.Container;
-import java.awt.Dialog;
+import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -34,8 +34,6 @@ import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPasswordField;
@@ -76,44 +74,48 @@ public class DGetNewPassword extends JEscDialog {
     /**
      * Creates new DGetNewPassword dialog where the parent is a frame.
      *
-     * @param parent      Parent frame
+     * @param parent      Parent window
      * @param title       The dialog's title
      * @param preferences Preferences
      */
-    public DGetNewPassword(JFrame parent, String title, KsePreferences preferences) {
-        this(parent, title, preferences, false, false);
+    public DGetNewPassword(Window parent, String title, KsePreferences preferences) {
+        this(parent, title, preferences, false, false, null);
+    }
+
+    /**
+     * Creates new DGetNewPassword dialog where the parent is a frame. This constructor
+     * accepts a current password for when a user is still in the process of setting a password.
+     *
+     * @param parent      Parent window
+     * @param title       The dialog's title
+     * @param preferences Preferences
+     * @param password    The current password
+     */
+    public DGetNewPassword(Window parent, String title, KsePreferences preferences, Password password) {
+        this(parent, title, preferences, false, false, password);
     }
 
     /**
      * Creates new DGetNewPassword dialog where the parent is a frame.
      *
-     * @param parent      Parent frame
+     * @param parent      Parent window
      * @param title       The dialog's title
      * @param preferences Preferences
      * @param askUserForPasswordManager Whether to show the checkbox asking the user if they want to use the pwd-mgr
      * @param usePasswordManagerEnabled Whether the checkbox for using the password manager is initially enabled
      */
-    public DGetNewPassword(JFrame parent, String title, KsePreferences preferences,
-                           boolean askUserForPasswordManager, boolean usePasswordManagerEnabled) {
+    public DGetNewPassword(Window parent, String title, KsePreferences preferences,
+            boolean askUserForPasswordManager, boolean usePasswordManagerEnabled) {
+        this(parent, title, preferences, askUserForPasswordManager, usePasswordManagerEnabled, null);
+    }
+
+    private DGetNewPassword(Window parent, String title, KsePreferences preferences,
+                           boolean askUserForPasswordManager, boolean usePasswordManagerEnabled, Password password) {
         super(parent, title, ModalityType.DOCUMENT_MODAL);
         this.preferences = preferences;
         this.askUserForPasswordManager = askUserForPasswordManager;
         this.usePasswordManagerEnabled = usePasswordManagerEnabled;
-        initComponents();
-    }
-
-    /**
-     * Creates new DGetNewPassword dialog where the parent is a dialog.
-     *
-     * @param parent      Parent dialog
-     * @param title       The dialog's title
-     * @param modality    Dialog modality
-     * @param preferences Preferences
-     */
-    public DGetNewPassword(JDialog parent, String title, Dialog.ModalityType modality,
-                           KsePreferences preferences) {
-        super(parent, title, modality);
-        this.preferences = preferences;
+        this.password = password;
         initComponents();
     }
 
@@ -125,8 +127,12 @@ public class DGetNewPassword extends JEscDialog {
         jpfConfirm = new JPasswordField(15);
         jpfConfirm.putClientProperty("JPasswordField.cutCopyAllowed", true);
 
-        if (preferences.getPasswordGeneratorSettings().isEnabled()) {
-            preFillPasswordFields(jpfFirst, jpfConfirm);
+        if (password == null) {
+            if (preferences.getPasswordGeneratorSettings().isEnabled()) {
+                preFillPasswordFields(jpfFirst, jpfConfirm);
+            }
+        } else {
+            preFillPasswordFields(jpfFirst, jpfConfirm, password.toCharArray());
         }
 
         jbOK = new JButton(res.getString("DGetNewPassword.jbOK.text"));

--- a/kse/src/main/java/org/kse/gui/password/PasswordDialogHelper.java
+++ b/kse/src/main/java/org/kse/gui/password/PasswordDialogHelper.java
@@ -25,7 +25,12 @@ import javax.swing.JPasswordField;
 import org.kse.gui.preferences.PreferencesManager;
 import org.kse.utilities.rng.PasswordGenerator;
 
+/**
+ * Utility methods for the password dialog.
+ */
 public class PasswordDialogHelper {
+
+    // Utility pattern
     private PasswordDialogHelper() {
     }
 
@@ -41,18 +46,30 @@ public class PasswordDialogHelper {
     public static void preFillPasswordFields(JComponent jpfFirst, JPasswordField jpfConfirm) {
         var generatorSettings = PreferencesManager.getPreferences().getPasswordGeneratorSettings();
         char[] generatedPassword = PasswordGenerator.generatePassword(generatorSettings);
+        preFillPasswordFields(jpfFirst, jpfConfirm, generatedPassword);
+    }
+
+    /**
+     * Prefills the password fields with a specified password.
+     *
+     * @param jpfFirst   the first password field
+     * @param jpfConfirm the second password field
+     * @param password   the password to pre-fill.
+     */
+    public static void preFillPasswordFields(JComponent jpfFirst, JPasswordField jpfConfirm, char[] password) {
         if (jpfFirst instanceof JPasswordQualityField) {
-            ((JPasswordQualityField) jpfFirst).setPassword(generatedPassword);
+            ((JPasswordQualityField) jpfFirst).setPassword(password);
         } else {
-            ((JPasswordField) jpfFirst).setText(new String(generatedPassword));
+            ((JPasswordField) jpfFirst).setText(new String(password));
         }
-        jpfConfirm.setText(new String(generatedPassword));
+        jpfConfirm.setText(new String(password));
     }
 
     /**
      * Creates a password input field with a quality indicator based on the current password quality settings
      * (or a normal one if password quality indicator is disabled in the settings).
      *
+     * @param passwordQualityConfig The password quality configuration settings
      * @return the password input field
      */
     public static JComponent createPasswordInputField(PasswordQualityConfig passwordQualityConfig) {
@@ -68,6 +85,5 @@ public class PasswordDialogHelper {
             return jPasswordField;
         }
     }
-
 
 }

--- a/kse/src/main/resources/org/kse/gui/dialogs/resources.properties
+++ b/kse/src/main/resources/org/kse/gui/dialogs/resources.properties
@@ -619,6 +619,7 @@ DViewPassword.jbUpdate.text              = Update
 DViewPassword.jlAlgorithm.text           = Algorithm:
 DViewPassword.jlPassword.text            = Password:
 DViewPassword.jtfAlgorithm.tooltip       = Password's encryption algorithm
+DViewPassword.NewPassphrase.title        = Update Passphrase
 
 DViewPem.ChooseExportFile.Title                 = Choose PEM Export File
 DViewPem.ChooseExportFile.button                = Choose


### PR DESCRIPTION
This PR fixes a minor workflow problem that can be encountered when storing a new passphrase.

Steps:

1. Click **Store Passphrase**
2. Click **Set**
3. Enter new and confirm passwords, and click **OK**
4. Click **Set**
5. Click **Cancel**

This shows a dialog that says the password cannot be empty, but from the UI it appears like a password is already set.
<img width="436" height="240" alt="image" src="https://github.com/user-attachments/assets/1fcd7d35-150c-4e89-9f6c-278ba8efea93" />


Also, this PR changes the update passphrase to use DGetNewPassword dialog rather than DChangePassword. The UI currently looks like this:
<img width="335" height="175" alt="image" src="https://github.com/user-attachments/assets/5908b9a3-3d1a-46ef-87e2-851d8351da39" />

Now it will look like this:
<img width="370" height="169" alt="image" src="https://github.com/user-attachments/assets/5357f0e4-5b62-4d10-a5af-ca18ed098f59" />

When using the feature, it seemed weird to have an old password that could not be viewed, and it didn't need to be provided for changing the password entry. Since I modified DGetNetPassword to work with an existing password, it seemed like a better option for updating the passphrase.

The update workflow remains unchanged. Clicking cancel will do nothing, and clicking OK will update the passphrase with the new value.