### PR TITLE
Fix layout of resizable dialogs when the dialog is expanded.

### DIFF
--- a/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
+++ b/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
@@ -112,10 +112,10 @@ public class DEnvironmentVariables extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspEnvironmentVariablesTable, "wrap para");
+        pane.add(jspEnvironmentVariablesTable, "grow, push, wrap para");
         pane.add(jbOK, "tag ok");
 
-        setResizable(false);
+        setResizable(true);
 
         addWindowListener(new WindowAdapter() {
             @Override

--- a/kse/src/main/java/org/kse/gui/about/DSystemInformation.java
+++ b/kse/src/main/java/org/kse/gui/about/DSystemInformation.java
@@ -265,14 +265,12 @@ public class DSystemInformation extends JEscDialog {
 
     private void systemPropertiesPressed() {
         DSystemProperties dSystemProperties = new DSystemProperties(this);
-        dSystemProperties.setResizable(true);
         dSystemProperties.setLocationRelativeTo(this);
         dSystemProperties.setVisible(true);
     }
 
     private void environmentVariablesPressed() {
         DEnvironmentVariables dEnvironmentVariables = new DEnvironmentVariables(this);
-        dEnvironmentVariables.setResizable(true);
         dEnvironmentVariables.setLocationRelativeTo(this);
         dEnvironmentVariables.setVisible(true);
     }

--- a/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
+++ b/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
@@ -112,10 +112,10 @@ public class DSystemProperties extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspSystemPropertiesTable, "wrap para");
+        pane.add(jspSystemPropertiesTable, "grow, push, wrap para");
         pane.add(jbOK, "tag ok");
 
-        setResizable(false);
+        setResizable(true);
 
         addWindowListener(new WindowAdapter() {
             @Override

--- a/kse/src/main/java/org/kse/gui/crypto/DProviderInfo.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DProviderInfo.java
@@ -120,7 +120,7 @@ public class DProviderInfo extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspProviders, "wrap para");
+        pane.add(jspProviders, "grow, push, wrap para");
         pane.add(jpButtons, "spanx, growx");
 
         setTitle(res.getString("DProviderInfo.Title"));

--- a/kse/src/main/java/org/kse/gui/crypto/DViewCertificateFingerprint.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DViewCertificateFingerprint.java
@@ -157,16 +157,16 @@ public class DViewCertificateFingerprint extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", "[]unrel[]"));
-        pane.add(jlFingerprint, "");
-        pane.add(jspFingerprint, "growx, height 80lp:80lp:80lp, width 30lp:400lp:n, wrap");
+        pane.add(jlFingerprint, "top");
+        pane.add(jspFingerprint, "grow, push, height 80lp:80lp:n, width 30lp:400lp:n, wrap");
 
-        pane.add(jlFormatFingerprint, "");
-        pane.add(jspFormatFingerprint, "growx, height 100lp:100lp:100lp, wrap");
+        pane.add(jlFormatFingerprint, "top");
+        pane.add(jspFormatFingerprint, "grow, push, height 100lp:100lp:n, wrap");
 
-        pane.add(jlBase64Fingerprint, "");
-        pane.add(jspBase64Fingerprint, "growx, height 60lp:60lp:60lp, wrap");
+        pane.add(jlBase64Fingerprint, "top");
+        pane.add(jspBase64Fingerprint, "grow, push, height 60lp:60lp:n, wrap");
 
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the text areas can grow
         pane.add(jpButtons, "spanx, growx");
 
         setTitle(MessageFormat.format(res.getString("DViewCertificateFingerprint.Title"), fingerprintAlg.friendly()));

--- a/kse/src/main/java/org/kse/gui/crypto/DViewPublicKeyFingerprint.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DViewPublicKeyFingerprint.java
@@ -157,16 +157,16 @@ public class DViewPublicKeyFingerprint extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", "[]unrel[]"));
-        pane.add(jlFingerprint, "");
-        pane.add(jspFingerprint, "growx, height 40lp:40lp:40lp, width 30lp:400lp:n, wrap");
+        pane.add(jlFingerprint, "top");
+        pane.add(jspFingerprint, "grow, push, height 40lp:40lp:n, width 30lp:400lp:n, wrap");
 
-        pane.add(jlFormatFingerprint, "");
-        pane.add(jspFormatFingerprint, "growx, height 60lp:60lp:60lp, wrap");
+        pane.add(jlFormatFingerprint, "top");
+        pane.add(jspFormatFingerprint, "grow, push, height 60lp:60lp:n, wrap");
 
-        pane.add(jlBase64Fingerprint, "");
-        pane.add(jspBase64Fingerprint, "growx, height 40lp:40lp:40lp, wrap");
+        pane.add(jlBase64Fingerprint, "top");
+        pane.add(jspBase64Fingerprint, "grow, push, height 40lp:40lp:n, wrap");
 
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the text areas can grow
         pane.add(jpButtons, "spanx, growx");
 
         setTitle(MessageFormat.format(res.getString("DViewPublicKeyFingerprint.Title"), fingerprintAlg.friendly()));

--- a/kse/src/main/java/org/kse/gui/dialogs/DCompareCertificates.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DCompareCertificates.java
@@ -179,16 +179,16 @@ public class DCompareCertificates extends JEscFrame {
 
         jpCompareCert = new JPanel();
         jpCompareCert.setLayout(new MigLayout("insets 0", "[]", "[]"));
-        jpCompareCert.add(editorLeft, "");
+        jpCompareCert.add(editorLeft, "grow, push");
         jpCompareCert.add(new JSeparator(SwingConstants.VERTICAL), "");
-        jpCompareCert.add(editorRight, "");
+        jpCompareCert.add(editorRight, "grow, push");
 
         jspCompareCert = PlatformUtil.createScrollPane(jpCompareCert, ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS,
                 ScrollPaneConstants.HORIZONTAL_SCROLLBAR_ALWAYS);
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets 0, fill", "[]", "[]"));
-        pane.add(jspCompareCert, "wrap, growx");
+        pane.add(jspCompareCert, "grow, push, wrap");
         pane.add(jpButtons, "spanx, growx");
 
         setResizable(true);

--- a/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
@@ -152,7 +152,7 @@ public class DProperties extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspProperties, "wrap para");
+        pane.add(jspProperties, "grow, push, wrap para");
         pane.add(jpButtons, "spanx, growx");
 
         setTitle(MessageFormat.format(res.getString("DProperties.Title"), history.getName()));

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewAsn1Dump.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewAsn1Dump.java
@@ -271,7 +271,7 @@ public class DViewAsn1Dump extends JEscFrame {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspAsn1Dump, "wrap para");
+        pane.add(jspAsn1Dump, "grow, push, wrap para");
         pane.add(jpButtons, "spanx, growx");
 
         setResizable(true);

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPem.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPem.java
@@ -225,7 +225,7 @@ public class DViewPem extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspPem, "wrap para");
+        pane.add(jspPem, "grow, push, wrap para");
         pane.add(jpButtons, "spanx, growx");
 
         setResizable(true);

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
@@ -116,8 +116,8 @@ public class DListCertificatesKS extends JEscDialog {
         pane.add(jlKeyStore, "split");
         pane.add(jcbKeyStore);
         pane.add(jbLoadKeystore, "wrap");
-        pane.add(jListCertificates, "spanx, push, grow, wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(jListCertificates, "spanx, grow, push, wrap");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the list can grow
         pane.add(jpButtons, "spanx, growx");
 
         jcbKeyStore.addActionListener(evt -> {

--- a/kse/src/main/java/org/kse/gui/error/DErrorDetail.java
+++ b/kse/src/main/java/org/kse/gui/error/DErrorDetail.java
@@ -118,7 +118,7 @@ public class DErrorDetail extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspError, "wrap para");
+        pane.add(jspError, "grow, push, wrap para");
         pane.add(jbCopy, "split 2");
         pane.add(jbOK, "tag ok");
 

--- a/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
+++ b/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
@@ -117,7 +117,7 @@ public class DJarInfo extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspJarInfoTable, "wrap para");
+        pane.add(jspJarInfoTable, "grow, push, wrap para");
         pane.add(jbOK, "tag ok");
 
         setResizable(true);


### PR DESCRIPTION
This PR makes the resizable dialogs grow correctly. Related to #725 and PR #803.

<img width="933" height="560" alt="image" src="https://github.com/user-attachments/assets/66d762a3-aad7-4beb-abd7-4ec77ae00731" />

<img width="758" height="509" alt="image" src="https://github.com/user-attachments/assets/9ba46a8c-e3be-4a8a-a865-4ae895f0bec8" />
