### PR TITLE
Fix automatic update checks across month boundaries

### DIFF
--- a/kse/src/main/java/org/kse/gui/actions/CheckUpdateAction.java
+++ b/kse/src/main/java/org/kse/gui/actions/CheckUpdateAction.java
@@ -26,7 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.MessageFormat;
 import java.time.LocalDate;
-import java.time.Period;
+import java.time.temporal.ChronoUnit;
 
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
@@ -96,7 +96,7 @@ public class CheckUpdateAction extends KeyStoreExplorerAction {
         LocalDate lastCheck = preferences.getAutoUpdateCheckSettings().getLastCheck();
         LocalDate now = LocalDate.now();
         int checkInterval = preferences.getAutoUpdateCheckSettings().getCheckInterval();
-        if (Period.between(lastCheck, now).getDays() < checkInterval) {
+        if (!isCheckDue(lastCheck, now, checkInterval)) {
             return;
         }
 
@@ -108,6 +108,10 @@ public class CheckUpdateAction extends KeyStoreExplorerAction {
         SwingUtilities.invokeLater(() -> {
             compareVersions(latestVersion, true);
         });
+    }
+
+    static boolean isCheckDue(LocalDate lastCheck, LocalDate now, int checkInterval) {
+        return ChronoUnit.DAYS.between(lastCheck, now) >= checkInterval;
     }
 
     private void compareVersions(Version latestVersion, boolean autoUpdateCheck) {

--- a/kse/src/test/java/org/kse/gui/actions/CheckUpdateActionTest.java
+++ b/kse/src/test/java/org/kse/gui/actions/CheckUpdateActionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.kse.gui.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class CheckUpdateActionTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "2026-07-01, 2026-07-14, 14, false",
+            "2026-07-01, 2026-07-15, 14, true",
+            "2026-07-01, 2026-08-01, 14, true",
+    })
+    void isCheckDue(String lastCheck, String now, int interval, boolean expected) {
+        assertThat(CheckUpdateAction.isCheckDue(LocalDate.parse(lastCheck), LocalDate.parse(now), interval))
+                .isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
## Summary

- Calculate automatic update-check intervals from total elapsed calendar days.
- Add regression coverage for the configured 14-day boundary and a month transition.

## Root cause

The prior calculation used the residual day component after whole months. A check last run on July 1 could therefore be skipped on August 1, despite 31 elapsed days.

## Validation

- Focused CheckUpdateAction test
- Full Gradle test suite
