### PR TITLE
📝 Fix links on Readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ ideas.
 Good documentation is crucial for any kind of software. You can help improving the documentation:
 * Please report missing, incorrect, or out-dated documentation as an [issue](https://github.com/kaikramer/keystore-explorer/issues).
 * The [KSE website](https://keystore-explorer.org) is in
-  a [GitHub repository](https://github.com/kaikramer/kaikramer.github.io) just like the KSE source code, which means
+  a [`kse-website` folder](https://github.com/kaikramer/keystore-explorer/tree/main/kse-website) just like the KSE source code, which means
   improvements for the website can be contributed in the same way as code contributions. Or you could open
   an [issue](https://github.com/kaikramer/keystore-explorer/issues) if you think the website could be improved, but
   don't want to do it yourself.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://img.shields.io/github/actions/workflow/status/kaikramer/keystore-explorer/build_test.yml)](https://github.com/kaikramer/keystore-explorer/actions/workflows/build_test.yml)
 [![Release](https://img.shields.io/github/v/release/kaikramer/keystore-explorer)](https://github.com/kaikramer/keystore-explorer/releases)
 [![Downloads](https://img.shields.io/github/downloads/kaikramer/keystore-explorer/total)](https://tooomm.github.io/github-release-stats/?username=kaikramer&repository=keystore-explorer)
-[![License](https://img.shields.io/github/license/kaikramer/keystore-explorer)](https://github.com/kaikramer/keystore-explorer/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/kaikramer/keystore-explorer)](https://github.com/kaikramer/keystore-explorer/blob/main/LICENSE)
 [![Packaging status](https://repology.org/badge/tiny-repos/keystore-explorer.svg)](https://repology.org/project/keystore-explorer/versions)
 [![Translation status](https://hosted.weblate.org/widgets/keystore-explorer/-/svg-badge.svg)](https://hosted.weblate.org/projects/keystore-explorer/)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/kaikramer/keystore-explorer)
@@ -94,7 +94,7 @@ Or run `org/kse/KSE.java` directly from an IDE.
 
 ## Contributing
 
-We encourage you to contribute to KSE! Please check out the [Contributing to KSE guide](https://github.com/kaikramer/keystore-explorer/blob/master/CONTRIBUTING.md) for guidelines about how to proceed.
+We encourage you to contribute to KSE! Please check out the [Contributing to KSE guide](https://github.com/kaikramer/keystore-explorer/blob/main/CONTRIBUTING.md) for guidelines about how to proceed.
 
 ## Translating
 
@@ -110,7 +110,7 @@ Use the "Resource Bundle Editor" plugin for JetBrains IDEs to simplify the proce
 
 ## License
 
-[GNU General Public License v3.0](https://github.com/kaikramer/keystore-explorer/blob/master/LICENSE)
+[GNU General Public License v3.0](https://github.com/kaikramer/keystore-explorer/blob/main/LICENSE)
 
 ## Sponsors
 

--- a/kse-website/README.md
+++ b/kse-website/README.md
@@ -9,8 +9,8 @@ Here is the Source code of the KeyStore Explorer website: https://keystore-explo
 Good documentation is crucial for any kind of software. You can help improving the documentation:
 * Please report missing, incorrect, or out-dated documentation as an
 [issue](https://github.com/kaikramer/keystore-explorer/issues).
-* The [KSE website](https://keystore-explorer.org) is in a [GitHub
-repository](https://github.com/kaikramer/kaikramer.github.io) just like the KSE
+* The [KSE website](https://keystore-explorer.org) is in a
+[`kse-website` folder](https://github.com/kaikramer/keystore-explorer/tree/main/kse-website) just like the KSE
 source code, which means improvements for the website can be contributed in the
 same way as code contributions. Or you could open an
 [issue](https://github.com/kaikramer/keystore-explorer/issues) if you think the


### PR DESCRIPTION
Hello KSE team, and @kaikramer,

This pull request updates documentation links throughout the project to consistently reference the `main` branch and the new location of the website source code. These changes help prevent confusion and ensure contributors are directed to the correct resources.

**Documentation link updates:**

* Updated all references to the `LICENSE` and `CONTRIBUTING.md` files from the `master` branch to the `main` branch in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L97-R97) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R113)
* Updated references to the KSE website source code from a separate GitHub repository to the `kse-website` folder within the main repository in both `CONTRIBUTING.md` and `kse-website/README.md`. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L65-R65) [[2]](diffhunk://#diff-3890d945bbf74f79760e5b0ee22729e6874f9708f97c80aaaae999b85e038ed3L12-R13)

Regards,
Th.