### PR TITLE
Set minimum dialog size. Remember and restore user-resized dimensions.

### DIFF
--- a/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
+++ b/kse/src/main/java/org/kse/gui/about/DEnvironmentVariables.java
@@ -37,7 +37,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.table.ToolTipTable;
 
 import net.miginfocom.swing.MigLayout;
@@ -45,7 +45,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * A dialog that displays the Environment variables.
  */
-public class DEnvironmentVariables extends JEscDialog {
+public class DEnvironmentVariables extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/about/resources");
@@ -128,15 +128,14 @@ public class DEnvironmentVariables extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
+++ b/kse/src/main/java/org/kse/gui/about/DSystemProperties.java
@@ -37,7 +37,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.table.ToolTipTable;
 
 import net.miginfocom.swing.MigLayout;
@@ -45,7 +45,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * A dialog that displays the Java System Properties.
  */
-public class DSystemProperties extends JEscDialog {
+public class DSystemProperties extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/about/resources");
@@ -128,15 +128,14 @@ public class DSystemProperties extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/components/JResizableDialog.java
+++ b/kse/src/main/java/org/kse/gui/components/JResizableDialog.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.gui.components;
+
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.Frame;
+import java.awt.GraphicsConfiguration;
+import java.awt.Window;
+
+import org.kse.gui.preferences.PreferencesManager;
+
+/**
+ * Extended dialog class that retains its size in preferences.
+ */
+public class JResizableDialog extends JEscDialog {
+    private static final long serialVersionUID = -3773740513817678414L;
+
+    public JResizableDialog() {
+        this((Frame) null, false);
+    }
+
+    public JResizableDialog(Frame owner) {
+        this(owner, false);
+    }
+
+    public JResizableDialog(Frame owner, boolean modal) {
+        this(owner, null, modal);
+    }
+
+    public JResizableDialog(Frame owner, String title) {
+        this(owner, title, false);
+    }
+
+    public JResizableDialog(Frame owner, String title, boolean modal) {
+        super(owner, title, modal);
+    }
+
+    public JResizableDialog(Frame owner, String title, boolean modal, GraphicsConfiguration gc) {
+        super(owner, title, modal, gc);
+    }
+
+    public JResizableDialog(Dialog owner) {
+        this(owner, false);
+    }
+
+    public JResizableDialog(Dialog owner, boolean modal) {
+        this(owner, null, modal);
+    }
+
+    public JResizableDialog(Dialog owner, String title) {
+        this(owner, title, false);
+    }
+
+    public JResizableDialog(Dialog owner, String title, boolean modal) {
+        super(owner, title, modal);
+    }
+
+    public JResizableDialog(Dialog owner, String title, boolean modal, GraphicsConfiguration gc) {
+        super(owner, title, modal, gc);
+    }
+
+    public JResizableDialog(Window owner, ModalityType modalityType) {
+        this(owner, "", modalityType);
+    }
+
+    public JResizableDialog(Window owner, String title, Dialog.ModalityType modalityType) {
+        super(owner, title, modalityType);
+    }
+
+    public JResizableDialog(Window owner, String title, Dialog.ModalityType modalityType, GraphicsConfiguration gc) {
+        super(owner, title, modalityType, gc);
+    }
+
+    protected void restoreSize() {
+        Dimension size = PreferencesManager.getPreferences().getDialogSizes().get(getClass().getSimpleName());
+        if (size != null) {
+            // It is technically better to use SwingUtilities.invokeLater, but that introduces
+            // a visible flicker that is noticeable when the preferences size is restored.
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                // Just continue if interrupted during the brief sleep.
+            }
+            setSize(size);
+        }
+    }
+
+    protected void closeDialog() {
+        PreferencesManager.getPreferences().getDialogSizes().put(getClass().getSimpleName(), getSize());
+        setVisible(false);
+        dispose();
+    }
+}

--- a/kse/src/main/java/org/kse/gui/components/JResizableFrame.java
+++ b/kse/src/main/java/org/kse/gui/components/JResizableFrame.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2004 - 2013 Wayne Grant
+ *           2013 - 2026 Kai Kramer
+ *
+ * This file is part of KeyStore Explorer.
+ *
+ * KeyStore Explorer is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KeyStore Explorer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KeyStore Explorer.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.kse.gui.components;
+
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+
+import org.kse.gui.preferences.PreferencesManager;
+
+/**
+ * Extended JFrame class that retains its size in preferences.
+ */
+public class JResizableFrame extends JEscFrame {
+    private static final long serialVersionUID = -3773740513817678414L;
+
+    public JResizableFrame() {
+        super();
+    }
+
+    public JResizableFrame(GraphicsConfiguration gc) {
+        super(gc);
+    }
+
+    public JResizableFrame(String title) {
+        super(title);
+    }
+
+    public JResizableFrame(String title, GraphicsConfiguration gc) {
+        super(title, gc);
+    }
+
+    protected void restoreSize() {
+        Dimension size = PreferencesManager.getPreferences().getDialogSizes().get(getClass().getSimpleName());
+        if (size != null) {
+            // It is technically better to use SwingUtilities.invokeLater, but that introduces
+            // a visible flicker that is noticeable when the preferences size is restored.
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                // Just continue if interrupted during the brief sleep.
+            }
+            setSize(size);
+        }
+    }
+
+    protected void closeFrame() {
+        PreferencesManager.getPreferences().getDialogSizes().put(getClass().getSimpleName(), getSize());
+        setVisible(false);
+        dispose();
+    }
+}

--- a/kse/src/main/java/org/kse/gui/crypto/DProviderInfo.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DProviderInfo.java
@@ -51,14 +51,14 @@ import javax.swing.tree.TreeSelectionModel;
 
 import org.kse.gui.CursorUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 
 import net.miginfocom.swing.MigLayout;
 
 /**
  * Displays information on the currently loaded security providers.
  */
-public class DProviderInfo extends JEscDialog {
+public class DProviderInfo extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static final ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/crypto/resources");
@@ -136,6 +136,10 @@ public class DProviderInfo extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -390,10 +394,5 @@ public class DProviderInfo extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/crypto/DViewCertificateFingerprint.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DViewCertificateFingerprint.java
@@ -62,7 +62,7 @@ import org.kse.crypto.x509.X509CertificateVersion;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.error.DError;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.io.HexUtil;
@@ -72,7 +72,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Dialog to view a certificate fingerprint.
  */
-public class DViewCertificateFingerprint extends JEscDialog {
+public class DViewCertificateFingerprint extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/crypto/resources");
@@ -183,6 +183,10 @@ public class DViewCertificateFingerprint extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
 
         populateFingerprint();
@@ -238,11 +242,6 @@ public class DViewCertificateFingerprint extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/crypto/DViewPublicKeyFingerprint.java
+++ b/kse/src/main/java/org/kse/gui/crypto/DViewPublicKeyFingerprint.java
@@ -20,6 +20,7 @@
 package org.kse.gui.crypto;
 
 import java.awt.Container;
+import java.awt.Dialog.ModalityType;
 import java.awt.Font;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
@@ -62,7 +63,7 @@ import org.kse.crypto.x509.X509CertificateVersion;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.error.DError;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.io.HexUtil;
@@ -72,7 +73,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Dialog to view a certificate fingerprint.
  */
-public class DViewPublicKeyFingerprint extends JEscDialog {
+public class DViewPublicKeyFingerprint extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/crypto/resources");
@@ -183,6 +184,10 @@ public class DViewPublicKeyFingerprint extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
 
         populateFingerprint();
@@ -236,11 +241,6 @@ public class DViewPublicKeyFingerprint extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/dialogs/DCompareCertificates.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DCompareCertificates.java
@@ -56,9 +56,9 @@ import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.crypto.x509.X509Ext;
 import org.kse.crypto.x509.X509ExtensionType;
-import org.kse.gui.components.JEscFrame;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
+import org.kse.gui.components.JResizableFrame;
 import org.kse.gui.error.DError;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.StringUtils;
@@ -68,13 +68,12 @@ import org.kse.utilities.io.IndentSequence;
 
 import com.github.difflib.text.DiffRow;
 import com.github.difflib.text.DiffRowGenerator;
-
 import net.miginfocom.swing.MigLayout;
 
 /**
  * Displays the differences of two certificates
  */
-public class DCompareCertificates extends JEscFrame {
+public class DCompareCertificates extends JResizableFrame {
 
     private static final long serialVersionUID = 1L;
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -195,6 +194,10 @@ public class DCompareCertificates extends JEscFrame {
 
         getRootPane().setDefaultButton(jbOK);
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         pack();
 
         // as the compare window can become quite large, we adjust its size depending on
@@ -297,12 +300,7 @@ public class DCompareCertificates extends JEscFrame {
     }
 
     private void okPressed() {
-        closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
+        closeFrame();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/dialogs/DPkcs12Info.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DPkcs12Info.java
@@ -105,7 +105,7 @@ import org.kse.crypto.CryptoException;
 import org.kse.crypto.secretkey.SecretKeyUtil;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.io.IndentSequence;
@@ -116,7 +116,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Displays the properties of a supplied KeyStore.
  */
-public class DPkcs12Info extends JEscDialog {
+public class DPkcs12Info extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static final ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -216,6 +216,10 @@ public class DPkcs12Info extends JEscDialog {
         getRootPane().setDefaultButton(jbOpen);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOpen.requestFocus());
     }
@@ -610,11 +614,6 @@ public class DPkcs12Info extends JEscDialog {
     private void cancelPressed() {
         cancelled = true;
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DProperties.java
@@ -76,7 +76,7 @@ import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.passwordmanager.Password;
 import org.kse.utilities.StringUtils;
 import org.kse.utilities.history.KeyStoreHistory;
@@ -88,7 +88,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Displays the properties of a supplied KeyStore.
  */
-public class DProperties extends JEscDialog {
+public class DProperties extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -168,6 +168,10 @@ public class DProperties extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -759,10 +763,5 @@ public class DProperties extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewAsn1Dump.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewAsn1Dump.java
@@ -50,7 +50,7 @@ import org.kse.crypto.x509.X509Ext;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscFrame;
+import org.kse.gui.components.JResizableFrame;
 import org.kse.utilities.asn1.Asn1Dump;
 import org.kse.utilities.asn1.Asn1Exception;
 
@@ -60,7 +60,7 @@ import net.miginfocom.swing.MigLayout;
  * Displays an ASN.1 dump of the supplied object: an X.509 certificate, private
  * key, public key, CRL, Extension, or CMS.
  */
-public class DViewAsn1Dump extends JEscFrame {
+public class DViewAsn1Dump extends JResizableFrame {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -279,13 +279,17 @@ public class DViewAsn1Dump extends JEscFrame {
         addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent evt) {
-                closeDialog();
+                closeFrame();
             }
         });
 
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -299,11 +303,6 @@ public class DViewAsn1Dump extends JEscFrame {
     }
 
     private void okPressed() {
-        closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
+        closeFrame();
     }
 }

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewPem.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewPem.java
@@ -68,7 +68,7 @@ import org.kse.gui.CursorUtil;
 import org.kse.gui.FileChooserFactory;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.error.DError;
 import org.kse.utilities.DialogViewer;
 
@@ -78,7 +78,7 @@ import net.miginfocom.swing.MigLayout;
  * Displays an X.509 certificate's PEM'd DER encoding and provides the
  * opportunity to export it to file.
  */
-public class DViewPem extends JEscDialog {
+public class DViewPem extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -240,6 +240,10 @@ public class DViewPem extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
 
@@ -334,11 +338,6 @@ public class DViewPem extends JEscDialog {
 
         JOptionPane.showMessageDialog(this, res.getString("DViewPem.ExportPemCertificateSuccessful.message"), title,
                                       JOptionPane.INFORMATION_MESSAGE);
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DListCertificatesKS.java
@@ -46,10 +46,10 @@ import javax.swing.JSeparator;
 import javax.swing.KeyStroke;
 import javax.swing.UnsupportedLookAndFeelException;
 
-import org.kse.gui.components.JEscDialog;
 import org.kse.gui.KseFrame;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.actions.OpenAction;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.utilities.DialogViewer;
 import org.kse.utilities.history.KeyStoreHistory;
 
@@ -58,7 +58,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Dialog that display a list of certificate from keystore
  */
-public class DListCertificatesKS extends JEscDialog {
+public class DListCertificatesKS extends JResizableDialog {
 
     private static final long serialVersionUID = 1L;
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/sign/resources");
@@ -162,6 +162,10 @@ public class DListCertificatesKS extends JEscDialog {
         setMinimumSize(new Dimension(400, 200));
         setResizable(true);
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         getRootPane().setDefaultButton(jbOK);
 
         pack();
@@ -192,11 +196,6 @@ public class DListCertificatesKS extends JEscDialog {
 
     private void cancelPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     private void okPressed() {

--- a/kse/src/main/java/org/kse/gui/error/DErrorDetail.java
+++ b/kse/src/main/java/org/kse/gui/error/DErrorDetail.java
@@ -44,7 +44,7 @@ import javax.swing.tree.TreeSelectionModel;
 
 import org.kse.gui.CursorUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -52,7 +52,7 @@ import net.miginfocom.swing.MigLayout;
  * Displays an error's stack trace. Cause error's stack trace will be show
  * recursively also.
  */
-public class DErrorDetail extends JEscDialog {
+public class DErrorDetail extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/error/resources");
@@ -136,6 +136,10 @@ public class DErrorDetail extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
 
@@ -204,10 +208,5 @@ public class DErrorDetail extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
+++ b/kse/src/main/java/org/kse/gui/jar/DJarInfo.java
@@ -44,7 +44,7 @@ import javax.swing.table.TableColumn;
 import javax.swing.table.TableRowSorter;
 
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.table.ToolTipTable;
 
 import net.miginfocom.swing.MigLayout;
@@ -52,7 +52,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * A dialog that displays information about the JAR files on the classpath.
  */
-public class DJarInfo extends JEscDialog {
+public class DJarInfo extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/jar/resources");
@@ -133,6 +133,10 @@ public class DJarInfo extends JEscDialog {
 
         pack();
 
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
+
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
 
@@ -201,10 +205,5 @@ public class DJarInfo extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/preferences/data/KsePreferences.java
+++ b/kse/src/main/java/org/kse/gui/preferences/data/KsePreferences.java
@@ -20,11 +20,13 @@
 
 package org.kse.gui.preferences.data;
 
+import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import javax.swing.JTabbedPane;
 
@@ -87,6 +89,8 @@ public class KsePreferences {
     private boolean silentlyReload = false;
     // Default to off for macOS since this features is not used.
     private boolean openWithExistingInstance = !OperatingSystem.isMacOs();
+    // TreeMap for storing the sizes in alphabetical order
+    private Map<String, Dimension> dialogSizes = new TreeMap<>();
 
     // auto-generated getters/setters
 
@@ -412,5 +416,13 @@ public class KsePreferences {
 
     public void setOpenWithExistingInstance(boolean openWithExistingInstance) {
         this.openWithExistingInstance = openWithExistingInstance;
+    }
+
+    public Map<String, Dimension> getDialogSizes() {
+        return dialogSizes;
+    }
+
+    public void setDialogSizes(Map<String, Dimension> dialogSizes) {
+        this.dialogSizes = dialogSizes;
     }
 }

--- a/kse/src/main/java/org/kse/gui/preferences/json/DimensionConverter.java
+++ b/kse/src/main/java/org/kse/gui/preferences/json/DimensionConverter.java
@@ -21,33 +21,41 @@
 package org.kse.gui.preferences.json;
 
 import java.awt.Dimension;
-import java.awt.Rectangle;
-import java.time.LocalDate;
+import java.io.IOException;
+import java.util.Map;
 
-import com.fasterxml.jackson.jr.ob.api.ReaderWriterProvider;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.jr.ob.api.ValueReader;
 import com.fasterxml.jackson.jr.ob.api.ValueWriter;
 import com.fasterxml.jackson.jr.ob.impl.JSONReader;
 import com.fasterxml.jackson.jr.ob.impl.JSONWriter;
 
 /**
- * Provide custom JSON converters for jackson-jr
+ * Custom JSON reader/writer because java.awt.Dimension causes issues with jackson
  */
-public class KseReaderWriterProvider extends ReaderWriterProvider {
+public class DimensionConverter extends ValueReader implements ValueWriter {
 
-    @Override
-    public ValueReader findValueReader(JSONReader readContext, Class<?> type) {
-        if (type == Dimension.class) return new DimensionConverter();
-        if (type == Rectangle.class) return new RectangleConverter();
-        if (type == LocalDate.class) return new LocalDateConverter();
-        return null;
+    protected DimensionConverter() {
+        super(Dimension.class);
     }
 
     @Override
-    public ValueWriter findValueWriter(JSONWriter writeContext, Class<?> type) {
-        if (type == Dimension.class) return new DimensionConverter();
-        if (type == Rectangle.class) return new RectangleConverter();
-        if (type == LocalDate.class) return new LocalDateConverter();
-        return null;
+    public void writeValue(JSONWriter context, JsonGenerator g, Object value) throws IOException {
+        Dimension dimension = (Dimension) value;
+        g.writeStartObject();
+        g.writeNumberField("width", dimension.width);
+        g.writeNumberField("height", dimension.height);
+        g.writeEndObject();
     }
+
+    @Override
+    public Object read(JSONReader reader, JsonParser p) throws IOException {
+        Map<String, Object> map = reader.readMap();
+        return new Dimension((Integer) map.get("width"),
+                             (Integer) map.get("height"));
+    }
+
+    @Override
+    public Class<Dimension> valueType() { return Dimension.class; }
 }


### PR DESCRIPTION
This PR sets a minimum dialog size for all resizable dialogs so that they cannot be resized such that the dialog buttons are hidden. The minimum size is set to the preferred size so that the dialogs always look good, and it makes it easy to restore the default size if desired.

It also updates KSE to remember the size of the dialog when the dialog is closed and the size is restored the next time the dialog is opened.