### PR TITLE
Updated several dialogs so that they are resizable.

### DIFF
--- a/kse/src/main/java/org/kse/gui/MiGUtil.java
+++ b/kse/src/main/java/org/kse/gui/MiGUtil.java
@@ -21,11 +21,18 @@ package org.kse.gui;
 
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
 
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
 
+/**
+ * Utilities for MiG Layout.
+ */
 public class MiGUtil {
 
     private MiGUtil() {
@@ -57,13 +64,30 @@ public class MiGUtil {
     /**
      * Creates a vertical separator for use between buttons.
      *
+     * @param visible True if the button separator is visible.
      * @return Button separator
      */
     public static JSeparator createButtonSeparator(boolean visible) {
-        JSeparator jSeparator = new JSeparator(JSeparator.VERTICAL);
+        JSeparator jSeparator = new JSeparator(SwingConstants.VERTICAL);
         jSeparator.setPreferredSize(new Dimension(3, 20));
         jSeparator.setVisible(visible);
 
         return jSeparator;
     }
+
+    /**
+     * Creates a spacer that is the same size as an 16x16 icon button. Each L&F creates
+     * buttons of differing sizes so this method uses a hidden 16x16 icon based button
+     * spacer that works for all L&F.
+     *
+     * @return A spacer.
+     */
+    public static JButton createIconButtonSpacer() {
+        Image image = new BufferedImage(16, 16, BufferedImage.TYPE_INT_ARGB);
+        JButton button = new JButton(new ImageIcon(image));
+        button.setEnabled(false);
+        button.setVisible(false);
+        return button;
+    }
+
 }

--- a/kse/src/main/java/org/kse/gui/crypto/JCertificateFingerprint.java
+++ b/kse/src/main/java/org/kse/gui/crypto/JCertificateFingerprint.java
@@ -88,7 +88,7 @@ public class JCertificateFingerprint extends JPanel {
 
         this.setLayout(new MigLayout("insets 0, fill", "[]", "[]"));
         this.add(jcbFingerprintAlg, "");
-        this.add(jtfCertificateFingerprint, "");
+        this.add(jtfCertificateFingerprint, "grow, push");
         this.add(jbViewCertificateFingerprint, "");
 
         populateFingerprintAlgs();

--- a/kse/src/main/java/org/kse/gui/crypto/JDistinguishedName.java
+++ b/kse/src/main/java/org/kse/gui/crypto/JDistinguishedName.java
@@ -108,8 +108,10 @@ public class JDistinguishedName extends JPanel {
             }
         });
 
-        setLayout(new MigLayout("insets 0, fill", "[]5px[]", ""));
-        add(jtfDistinguishedName, "");
+        // use related spacing (MiG layout default) to match DViewCertificate
+        // and other view dialogs "split" (example: jtfPublicKey)
+        setLayout(new MigLayout("insets 0, fill", "[]", ""));
+        add(jtfDistinguishedName, "grow, push");
         add(jbViewEditDistinguishedName, "");
 
         if (editable) {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewCertificate.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewCertificate.java
@@ -79,11 +79,12 @@ import org.kse.crypto.x509.X509CertificateGenerator;
 import org.kse.crypto.x509.X509CertificateVersion;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.KseFrame;
+import org.kse.gui.MiGUtil;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.actions.ExportTrustedCertificateAction;
 import org.kse.gui.actions.ImportTrustedCertificateAction;
 import org.kse.gui.actions.VerifyCertificateAction;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.crypto.JCertificateFingerprint;
 import org.kse.gui.crypto.JDistinguishedName;
 import org.kse.gui.dialogs.extensions.DViewExtensions;
@@ -101,7 +102,7 @@ import net.miginfocom.swing.MigLayout;
  * certificate are displayed at a time with selector buttons allowing the
  * movement to another of the certificates.
  */
-public class DViewCertificate extends JEscDialog {
+public class DViewCertificate extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -299,31 +300,40 @@ public class DViewCertificate extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", "[]unrel[]"));
-        pane.add(jlHierarchy, "");
-        pane.add(jspHierarchy, "sgx, wrap");
+        pane.add(jlHierarchy, "top");
+        pane.add(jspHierarchy, "grow, push, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlVersion, "");
-        pane.add(jtfVersion, "sgx, wrap");
+        pane.add(jtfVersion, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlSubject, "");
-        pane.add(jdnSubject, "wrap");
+        pane.add(jdnSubject, "growx, wrap");
         pane.add(jlIssuer, "");
-        pane.add(jdnIssuer, "wrap");
+        pane.add(jdnIssuer, "growx, wrap");
         pane.add(jlSerialNumberHex, "");
-        pane.add(jtfSerialNumberHex, "wrap");
+        pane.add(jtfSerialNumberHex, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlSerialNumberDec, "");
-        pane.add(jtfSerialNumberDec, "wrap");
+        pane.add(jtfSerialNumberDec, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlValidFrom, "");
-        pane.add(jtfValidFrom, "wrap");
+        pane.add(jtfValidFrom, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlValidUntil, "");
-        pane.add(jtfValidUntil, "wrap");
+        pane.add(jtfValidUntil, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlValidityProgress, "");
-        pane.add(jpbValidityProgress, "sgx, wrap");
+        pane.add(jpbValidityProgress, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlValidityDays);
-        pane.add(jtfValidityDays, "wrap");
+        pane.add(jtfValidityDays, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlPublicKey, "");
-        pane.add(jtfPublicKey, "spanx, split");
+        pane.add(jtfPublicKey, "growx, pushx, split");
         pane.add(jbViewPublicKeyDetails, "wrap");
         pane.add(jlSignatureAlgorithm, "");
-        pane.add(jtfSignatureAlgorithm, "wrap");
+        pane.add(jtfSignatureAlgorithm, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlFingerprint, "");
         pane.add(jcfFingerprint, "spanx, growx, wrap para");
         pane.add(jbImport, "hidemode 1, spanx, split");
@@ -334,7 +344,7 @@ public class DViewCertificate extends JEscDialog {
         pane.add(jbExtensions, "");
         pane.add(jbPem, "");
         pane.add(jbAsn1, "wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the tree view can grow
         pane.add(jbOK, "spanx, tag ok");
 
         jtrHierarchy.addTreeSelectionListener(evt -> {
@@ -418,7 +428,7 @@ public class DViewCertificate extends JEscDialog {
             }
         });
 
-        setResizable(false);
+        setResizable(true);
 
         // select (first) leaf in certificate tree
         DefaultMutableTreeNode firstLeaf = ((DefaultMutableTreeNode) topNode).getFirstLeaf();
@@ -427,6 +437,10 @@ public class DViewCertificate extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -749,11 +763,6 @@ public class DViewCertificate extends JEscDialog {
     private void okPressed() {
         preferences.setCertificateFingerprintAlgorithm(jcfFingerprint.getSelectedFingerprintAlg());
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     private class X509CertificateComparator implements Comparator<X509Certificate> {

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewCrl.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewCrl.java
@@ -58,8 +58,9 @@ import org.kse.crypto.signing.SignatureType;
 import org.kse.crypto.x509.X500NameUtils;
 import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CursorUtil;
+import org.kse.gui.MiGUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.crypto.JDistinguishedName;
 import org.kse.gui.dialogs.extensions.DViewExtensions;
 import org.kse.gui.error.DError;
@@ -73,7 +74,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Displays the details of a Certificate Revocation List (CRL).
  */
-public class DViewCrl extends JEscDialog {
+public class DViewCrl extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static final int TEXT_FIELD_WIDTH = 40;
@@ -256,28 +257,32 @@ public class DViewCrl extends JEscDialog {
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", ""));
 
         pane.add(jlVersion, "");
-        pane.add(jtfVersion, "wrap");
+        pane.add(jtfVersion, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlIssuer, "");
-        pane.add(jdnIssuer, "wrap");
+        pane.add(jdnIssuer, "growx, wrap");
         pane.add(jlEffectiveDate, "");
-        pane.add(jtfEffectiveDate, "wrap");
+        pane.add(jtfEffectiveDate, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlNextUpdate, "");
-        pane.add(jtfNextUpdate, "wrap");
+        pane.add(jtfNextUpdate, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlSignatureAlgorithm, "");
-        pane.add(jtfSignatureAlgorithm, "wrap para");
+        pane.add(jtfSignatureAlgorithm, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap para");
         pane.add(jbCrlExtensions, "spanx, split");
         pane.add(jbCrlPem, "");
         pane.add(jbCrlAsn1, "wrap unrel");
         pane.add(new JSeparator(), "spanx, growx, wrap");
         pane.add(jlRevokedCerts, "split, wrap");
-        pane.add(jspRevokedCertsTable, "spanx, growx, wrap para");
+        pane.add(jspRevokedCertsTable, "spanx, grow, push, wrap para");
         pane.add(jbCrlEntryExtensions, "spanx, wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the table can grow
         pane.add(jbOK, "spanx, tag ok");
 
         populateDialog();
 
-        setResizable(false);
+        setResizable(true);
 
         addWindowListener(new WindowAdapter() {
             @Override
@@ -289,6 +294,10 @@ public class DViewCrl extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -475,11 +484,6 @@ public class DViewCrl extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     // for quick testing

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewSignature.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewSignature.java
@@ -80,8 +80,9 @@ import org.kse.crypto.x509.X509CertificateGenerator;
 import org.kse.crypto.x509.X509CertificateVersion;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.KseFrame;
+import org.kse.gui.MiGUtil;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.crypto.JDistinguishedName;
 import org.kse.gui.error.DError;
 import org.kse.utilities.DialogViewer;
@@ -95,7 +96,7 @@ import net.miginfocom.swing.MigLayout;
  * signer are displayed at a time with selector buttons allowing the
  * movement to another of the signers.
  */
-public class DViewSignature extends JEscDialog {
+public class DViewSignature extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -233,27 +234,32 @@ public class DViewSignature extends JEscDialog {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", "[]unrel[]"));
-        pane.add(jlSigners, "");
-        pane.add(jspSigners, "sgx, wrap");
+        pane.add(jlSigners, "top");
+        pane.add(jspSigners, "grow, push, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlStatus, "");
-        pane.add(jtfStatus, "sgx, wrap");
+        pane.add(jtfStatus, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlVersion, "");
-        pane.add(jtfVersion, "wrap");
+        pane.add(jtfVersion, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlSubject, "");
-        pane.add(jdnSubject, "wrap");
+        pane.add(jdnSubject, "growx, wrap");
         pane.add(jlIssuer, "");
-        pane.add(jdnIssuer, "wrap");
+        pane.add(jdnIssuer, "growx, wrap");
         pane.add(jlSigningTime, "");
-        pane.add(jtfSigningTime, "wrap");
+        pane.add(jtfSigningTime, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap");
         pane.add(jlSignatureAlgorithm, "");
-        pane.add(jtfSignatureAlgorithm, "wrap para");
+        pane.add(jtfSignatureAlgorithm, "growx, pushx, split");
+        pane.add(MiGUtil.createIconButtonSpacer(), "wrap para");
         pane.add(jbTimeStamp, "spanx, split");
         pane.add(jbSignerAsn1, "wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15");
         pane.add(jbCertificates, "spanx, split");
         pane.add(jbPem, "");
         pane.add(jbAsn1, "wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15"); // don't push so that the list can grow
         pane.add(jbOK, "spanx, tag ok");
 
         jtrSigners.addTreeSelectionListener(evt -> {
@@ -319,7 +325,7 @@ public class DViewSignature extends JEscDialog {
             }
         });
 
-        setResizable(false);
+        setResizable(true);
 
         // select (first) child in signers tree
         TreeNode firstChild = ((DefaultMutableTreeNode) topNode).getFirstChild();
@@ -328,6 +334,10 @@ public class DViewSignature extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -568,11 +578,6 @@ public class DViewSignature extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     /**

--- a/kse/src/main/java/org/kse/gui/dialogs/DViewSignedJar.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/DViewSignedJar.java
@@ -61,7 +61,7 @@ import org.kse.crypto.x509.X509CertUtil;
 import org.kse.gui.CursorUtil;
 import org.kse.gui.KseFrame;
 import org.kse.gui.PlatformUtil;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.error.DError;
 import org.kse.gui.table.ToolTipTable;
 import org.kse.utilities.StringUtils;
@@ -71,7 +71,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Displays the details of a signed JAR file.
  */
-public class DViewSignedJar extends JEscDialog {
+public class DViewSignedJar extends JResizableDialog {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/resources");
@@ -201,16 +201,16 @@ public class DViewSignedJar extends JEscDialog {
         pane.setLayout(new MigLayout("insets dialog, fill", "[right]unrel[]", ""));
 
         pane.add(jlVerifyStatus, "");
-        pane.add(jtfVerifyStatus, "growx, wrap");
-        pane.add(jspJarEntryTable, "spanx, growx, wrap para");
+        pane.add(jtfVerifyStatus, "growx, pushx, wrap");
+        pane.add(jspJarEntryTable, "spanx, grow, push, wrap para");
         pane.add(jbSignatures, "spanx, split");
         pane.add(jbJarEntryCertificates, "wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15");  // don't push so that the table can grow
         pane.add(jbOK, "spanx, tag ok");
 
         populateDialog();
 
-        setResizable(false);
+        setResizable(true);
 
         addWindowListener(new WindowAdapter() {
             @Override
@@ -222,6 +222,10 @@ public class DViewSignedJar extends JEscDialog {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -317,10 +321,5 @@ public class DViewSignedJar extends JEscDialog {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 }

--- a/kse/src/main/java/org/kse/gui/dialogs/extensions/DViewExtensions.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/extensions/DViewExtensions.java
@@ -62,7 +62,7 @@ import org.kse.gui.KseFrame;
 import org.kse.gui.LnfUtil;
 import org.kse.gui.PlatformUtil;
 import org.kse.gui.actions.ExamineClipboardAction;
-import org.kse.gui.components.JEscDialog;
+import org.kse.gui.components.JResizableDialog;
 import org.kse.gui.dialogs.DViewAsn1Dump;
 import org.kse.gui.error.DError;
 import org.kse.gui.table.ToolTipTable;
@@ -75,7 +75,7 @@ import net.miginfocom.swing.MigLayout;
 /**
  * Displays the details of X.509 Extensions.
  */
-public class DViewExtensions extends JEscDialog implements HyperlinkListener {
+public class DViewExtensions extends JResizableDialog implements HyperlinkListener {
     private static final long serialVersionUID = 1L;
 
     private static ResourceBundle res = ResourceBundle.getBundle("org/kse/gui/dialogs/extensions/resources");
@@ -248,17 +248,17 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
 
         Container pane = getContentPane();
         pane.setLayout(new MigLayout("insets dialog, fill", "[]", "[]"));
-        pane.add(jspExtensionsTable, "growx, wrap");
+        pane.add(jspExtensionsTable, "grow, push, wrap");
         pane.add(jlExtensionValue, "wrap");
-        pane.add(jspExtensionValue, "wrap para");
+        pane.add(jspExtensionValue, "grow, push, wrap para");
         pane.add(jbCopy, "right, spanx, split 4");
         addButtonSeparator(pane, true);
         pane.add(jbSaveTemplate);
         pane.add(jbAsn1, "wrap");
-        pane.add(new JSeparator(), "spanx, growx, wrap 15:push");
+        pane.add(new JSeparator(), "spanx, growx, wrap 15");  // don't push so that the table and text area can grow
         pane.add(jbOK, "spanx, tag ok");
 
-        setResizable(false);
+        setResizable(true);
 
         addWindowListener(new WindowAdapter() {
             @Override
@@ -270,6 +270,10 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
         getRootPane().setDefaultButton(jbOK);
 
         pack();
+
+        // set the minimum size to preferred size so that the dialog always looks good
+        setMinimumSize(getPreferredSize());
+        restoreSize();
 
         SwingUtilities.invokeLater(() -> jbOK.requestFocus());
     }
@@ -348,11 +352,6 @@ public class DViewExtensions extends JEscDialog implements HyperlinkListener {
 
     private void okPressed() {
         closeDialog();
-    }
-
-    private void closeDialog() {
-        setVisible(false);
-        dispose();
     }
 
     @Override

--- a/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
+++ b/kse/src/main/java/org/kse/gui/dialogs/sign/DSignCsr.java
@@ -330,7 +330,7 @@ public class DSignCsr extends JEscDialog {
         pane.add(jdnCsrSubject, "wrap");
         pane.add(jlCsrPublicKey, "");
         pane.add(jtfCsrPublicKey, "split 2");
-        pane.add(jbViewCsrPublicKeyDetails, "gapx 5px, wrap");
+        pane.add(jbViewCsrPublicKeyDetails, "gapx rel, wrap");
         pane.add(jlCsrSignatureAlgorithm, "");
         pane.add(jtfCsrSignatureAlgorithm, "wrap");
         pane.add(jlCsrChallenge, "");


### PR DESCRIPTION
This PR resolves #463 by making several additional dialogs resizable. It also ensures that the text field lengths in DViewCertificate, DViewSignature and DViewCrl are identical for all L&F on all platforms by adding a spacer that is the same size as the icon buttons.

DViewCertificate
<img width="1085" height="725" alt="image" src="https://github.com/user-attachments/assets/ed1de47e-270e-464a-ab95-68719e634dfd" />

DViewCrl
<img width="912" height="734" alt="image" src="https://github.com/user-attachments/assets/11b056bc-cc8d-4fd3-acad-4f0a561742e2" />

DViewSignedJar
<img width="860" height="507" alt="image" src="https://github.com/user-attachments/assets/7223de4b-4974-4fab-a71b-e71a184f8b81" />

DViewSignature
<img width="888" height="616" alt="image" src="https://github.com/user-attachments/assets/6e275db8-267d-4761-88ee-6c498b49dbc3" />

DViewExtensions
<img width="820" height="642" alt="image" src="https://github.com/user-attachments/assets/44e19f95-c56a-49f9-9d39-25d3d1e07063" />
